### PR TITLE
Add case study view with inline video demos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,16 @@ DATABASE_URL="postgresql://postgres:password@localhost:5432/cur8d"
 NOTION_DATABASE_ID="87a11304-065c-41ff-bf52-64164ccd36bc"
 NOTION_API_KEY="secret_1234567890"
 
+# Notion "design / case studies" database. Must be shared with the integration
+# above, otherwise queries come back empty.
+NOTION_CASE_STUDY_DATABASE_ID="944872db-d32d-4735-b7c6-d466fe57fce2"
+
+# Used to generate case study summaries during sync.
+ANTHROPIC_API_KEY="sk-ant-1234567890"
+
+# Vercel Blob, used to host demo videos and their poster frames.
+BLOB_READ_WRITE_TOKEN="vercel_blob_rw_1234567890"
+
 # Example:
 # SERVERVAR="foo"
 # NEXT_PUBLIC_CLIENTVAR="bar"

--- a/.env.example
+++ b/.env.example
@@ -16,14 +16,21 @@ DATABASE_URL="postgresql://postgres:password@localhost:5432/cur8d"
 NOTION_DATABASE_ID="87a11304-065c-41ff-bf52-64164ccd36bc"
 NOTION_API_KEY="secret_1234567890"
 
+# --- Case studies (all optional) ---------------------------------------------
+# The app builds and serves the designer view without any of these. Leave them
+# unset and the case study sync simply no-ops.
+
 # Notion "design / case studies" database. Must be shared with the integration
 # above, otherwise queries come back empty.
 NOTION_CASE_STUDY_DATABASE_ID="944872db-d32d-4735-b7c6-d466fe57fce2"
 
-# Used to generate case study summaries during sync.
+# Used to generate case study summaries during sync. Without it, rows sync but
+# get no summary.
 ANTHROPIC_API_KEY="sk-ant-1234567890"
 
-# Vercel Blob, used to host demo videos and their poster frames.
+# Hosts demo videos and their poster frames. On Vercel this is injected
+# automatically once a Blob store is connected to the project — only set it by
+# hand for local runs of `npm run ingest:video`.
 BLOB_READ_WRITE_TOKEN="vercel_blob_rw_1234567890"
 
 # Example:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cur8d",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.115.0",
         "@notionhq/client": "^2.3.0",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-dialog": "^1.1.6",
@@ -20,6 +21,7 @@
         "@trpc/react-query": "^11.0.0-rc.446",
         "@trpc/server": "^11.0.0-rc.446",
         "@vercel/analytics": "^2.0.1",
+        "@vercel/blob": "^2.6.1",
         "cheerio": "^1.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -48,6 +50,7 @@
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^8.1.0",
         "@typescript-eslint/parser": "^8.1.0",
+        "dotenv": "^17.4.2",
         "drizzle-kit": "^0.24.0",
         "eslint": "^8.57.0",
         "eslint-config-next": "^15.0.1",
@@ -56,6 +59,7 @@
         "prettier": "^3.3.2",
         "prettier-plugin-tailwindcss": "^0.6.5",
         "tailwindcss": "^3.4.3",
+        "tsx": "^4.23.1",
         "typescript": "^5.5.3"
       }
     },
@@ -69,6 +73,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.115.0.tgz",
+      "integrity": "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -100,6 +134,57 @@
         "source-map-support": "^0.5.21"
       }
     },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-arm64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
@@ -112,6 +197,312 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -167,6 +558,74 @@
         "get-tsconfig": "^4.7.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.19.12",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
@@ -182,6 +641,363 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2123,6 +2939,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -2615,6 +3437,77 @@
         }
       }
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.6.1.tgz",
+      "integrity": "sha512-KTJytw85j1XQBxjN5d6UXI7fIWNQe1jotn4nWN+0hePqLs+Qi1B3jHdQcSKFGF0m2rsy9uhPT6GOXMtHe3qNzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "^3.6.1",
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/blob/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.1.tgz",
+      "integrity": "sha512-RhfyXmRLHdbnry8RJqHDc+5rGxMZ0bu+fpysZjtv3bE+BubpuwxTancHOKiH5zKQREsdwFVr3mOI2kOvxlOyxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/cli-exec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.0.tgz",
+      "integrity": "sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.1.tgz",
+      "integrity": "sha512-ufdalm2MWOYksyj8KVpWjoOFPJO6zoYpuyvIggIQ2bB0CFCjTCiTkGXHqAKwG77GVRjOaN3/8S5ITlZpXWmqOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.1",
+        "@vercel/cli-exec": "1.0.0",
+        "jose": "^5.9.6"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2908,6 +3801,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/asynckit": {
@@ -3599,6 +4501,19 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/drizzle-kit": {
       "version": "0.24.2",
       "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.24.2.tgz",
@@ -4010,6 +4925,380 @@
       },
       "peerDependencies": {
         "esbuild": ">=0.12 <1"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+      "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -4589,6 +5878,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4637,6 +5955,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -4891,6 +6215,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -5156,6 +6492,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -5329,6 +6674,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -5493,6 +6861,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5575,6 +6949,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -5741,6 +7127,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5766,6 +7161,19 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -5931,6 +7339,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5972,6 +7386,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/minimatch": {
@@ -6235,6 +7658,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -6421,6 +7856,21 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6437,6 +7887,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/own-keys": {
@@ -7148,6 +8607,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7542,6 +9010,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -7775,6 +9253,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-json-comments": {
@@ -8020,6 +9507,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -8083,6 +9582,12 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -8120,6 +9625,84 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -8630,6 +10213,31 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xdg-app-paths": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+      "integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1",
+        "xdg-portable": "^7.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
     },
     "node_modules/yaml": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "dev": "next dev --turbo",
+    "ingest:video": "tsx scripts/ingest-video.ts",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "format:write": "prettier --write \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "lint": "next lint",
@@ -20,6 +21,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.115.0",
     "@notionhq/client": "^2.3.0",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-dialog": "^1.1.6",
@@ -32,6 +34,7 @@
     "@trpc/react-query": "^11.0.0-rc.446",
     "@trpc/server": "^11.0.0-rc.446",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/blob": "^2.6.1",
     "cheerio": "^1.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -60,6 +63,7 @@
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^8.1.0",
     "@typescript-eslint/parser": "^8.1.0",
+    "dotenv": "^17.4.2",
     "drizzle-kit": "^0.24.0",
     "eslint": "^8.57.0",
     "eslint-config-next": "^15.0.1",
@@ -68,6 +72,7 @@
     "prettier": "^3.3.2",
     "prettier-plugin-tailwindcss": "^0.6.5",
     "tailwindcss": "^3.4.3",
+    "tsx": "^4.23.1",
     "typescript": "^5.5.3"
   },
   "ct3aMetadata": {

--- a/scripts/ingest-video.ts
+++ b/scripts/ingest-video.ts
@@ -1,0 +1,168 @@
+/**
+ * Pulls a demo video into Vercel Blob and records it on a Notion case study.
+ *
+ * Run this locally, not on Vercel. X blocks requests from data-centre IP
+ * ranges, so extraction only works from an ordinary residential connection —
+ * which is the whole reason this step lives outside the cron.
+ *
+ *   npm run ingest:video -- <tweet-url|video-url|file-path> --page <notion-page-id>
+ *
+ * Writes the resulting Blob URLs into the page's Video / Poster properties and
+ * the tweet copy into Source Text. Notion stays the source of truth; the cron
+ * picks the row up on its next run.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, extname, join } from "node:path";
+import { Client as NotionClient } from "@notionhq/client";
+import { config } from "dotenv";
+import { uploadFileToBlob } from "../src/lib/blob-storage";
+
+config();
+
+const IMAGE_CONTENT_TYPES: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".webp": "image/webp",
+};
+
+interface Args {
+  source: string;
+  pageId: string;
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const pageFlag = argv.indexOf("--page");
+
+  const source = argv.find((arg) => !arg.startsWith("--") && arg !== argv[pageFlag + 1]);
+  const pageId = pageFlag === -1 ? undefined : argv[pageFlag + 1];
+
+  if (!source || !pageId) {
+    console.error(
+      "Usage: npm run ingest:video -- <tweet-url|video-url|file-path> --page <notion-page-id>",
+    );
+    process.exit(1);
+  }
+
+  return { source, pageId };
+}
+
+function isRemote(source: string) {
+  return source.startsWith("http://") || source.startsWith("https://");
+}
+
+function run(command: string, args: string[]) {
+  const result = spawnSync(command, args, { stdio: ["ignore", "pipe", "inherit"] });
+
+  if (result.error) {
+    throw new Error(
+      `Could not run \`${command}\`. Install it first (brew install yt-dlp).`,
+    );
+  }
+  if (result.status !== 0) {
+    throw new Error(`\`${command}\` exited with code ${result.status}`);
+  }
+
+  return result.stdout.toString().trim();
+}
+
+/** Downloads the video, its poster frame, and the post text via yt-dlp. */
+function extractWithYtDlp(url: string, workDir: string) {
+  console.log("Extracting media with yt-dlp…");
+
+  run("yt-dlp", [
+    "--no-playlist",
+    "--write-thumbnail",
+    "--convert-thumbnails",
+    "jpg",
+    "--merge-output-format",
+    "mp4",
+    "-o",
+    join(workDir, "media.%(ext)s"),
+    url,
+  ]);
+
+  const description = run("yt-dlp", [
+    "--no-playlist",
+    "--skip-download",
+    "--print",
+    "%(description)s",
+    url,
+  ]);
+
+  const files = readdirSync(workDir);
+  const videoFile = files.find((file) => file.endsWith(".mp4"));
+  const posterFile = files.find((file) => /\.(jpe?g|png|webp)$/i.test(file));
+
+  if (!videoFile) {
+    throw new Error("yt-dlp did not produce a video file for this URL.");
+  }
+
+  return {
+    videoPath: join(workDir, videoFile),
+    posterPath: posterFile ? join(workDir, posterFile) : null,
+    sourceText: description === "NA" ? null : description,
+  };
+}
+
+async function main() {
+  const { source, pageId } = parseArgs();
+  const notion = new NotionClient({ auth: process.env.NOTION_API_KEY });
+
+  const workDir = mkdtempSync(join(tmpdir(), "cur8d-ingest-"));
+
+  try {
+    const media = isRemote(source)
+      ? extractWithYtDlp(source, workDir)
+      : { videoPath: source, posterPath: null, sourceText: null };
+
+    console.log("Uploading video to Blob…");
+    const videoUrl = await uploadFileToBlob(
+      readFileSync(media.videoPath),
+      `case-studies/${pageId}/${basename(media.videoPath)}`,
+      "video/mp4",
+    );
+
+    let posterUrl: string | null = null;
+    if (media.posterPath) {
+      console.log("Uploading poster to Blob…");
+      const extension = extname(media.posterPath).toLowerCase();
+      posterUrl = await uploadFileToBlob(
+        readFileSync(media.posterPath),
+        `case-studies/${pageId}/${basename(media.posterPath)}`,
+        IMAGE_CONTENT_TYPES[extension] ?? "image/jpeg",
+      );
+    }
+
+    console.log("Writing URLs back to Notion…");
+    await notion.pages.update({
+      page_id: pageId,
+      properties: {
+        Video: { url: videoUrl },
+        ...(posterUrl ? { Poster: { url: posterUrl } } : {}),
+        ...(media.sourceText
+          ? {
+              "Source Text": {
+                rich_text: [{ text: { content: media.sourceText.slice(0, 2000) } }],
+              },
+            }
+          : {}),
+      },
+    });
+
+    console.log("\nDone.");
+    console.log("  Video: ", videoUrl);
+    if (posterUrl) console.log("  Poster:", posterUrl);
+    console.log("\nRun GET /api/case-study-sync to pull it through to the site.");
+  } finally {
+    if (isRemote(source)) rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error("\nIngest failed:", error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/src/app/api/case-study-sync/route.ts
+++ b/src/app/api/case-study-sync/route.ts
@@ -1,0 +1,188 @@
+import { NextResponse } from "next/server";
+import { eq, inArray } from "drizzle-orm";
+import {
+  fetchCaseStudyData,
+  type NotionCaseStudy,
+} from "@/lib/case-study-sync";
+import { generateSummary } from "@/lib/ai-summary";
+import { mirrorToBlob } from "@/lib/blob-storage";
+import { fetchScreenshotUrl } from "@/lib/screenshot";
+import { db } from "@/server/db";
+import { caseStudies } from "@/server/db/schema";
+
+export const maxDuration = 60;
+
+type DbCaseStudy = typeof caseStudies.$inferSelect;
+
+/** Drops tags that no longer exist as options in Notion. */
+async function cleanupOrphanedIndustries(notionItems: NotionCaseStudy[]) {
+  const validIndustries = new Set(notionItems.flatMap((item) => item.industries));
+  const dbItems = await db.query.caseStudies.findMany();
+
+  const stale = dbItems.filter((item) =>
+    item.industries?.some((industry) => !validIndustries.has(industry)),
+  );
+
+  await Promise.all(
+    stale.map((item) =>
+      db
+        .update(caseStudies)
+        .set({
+          industries:
+            item.industries?.filter((industry) =>
+              validIndustries.has(industry),
+            ) ?? [],
+        })
+        .where(eq(caseStudies.id, item.id)),
+    ),
+  );
+
+  return stale.length;
+}
+
+/**
+ * Resolves the media for one row and writes it back.
+ *
+ * Video wins when Notion has one: the file is mirrored into Blob so playback
+ * doesn't depend on an expiring Notion URL. Website entries fall back to a
+ * screenshot. Either way the summary comes last, since it can reuse the
+ * captured source text.
+ */
+async function enrichCaseStudy(item: NotionCaseStudy) {
+  const [videoUrl, posterUrl] = await Promise.all([
+    item.videoUrl
+      ? mirrorToBlob(item.videoUrl, `case-studies/${item.id}/video.mp4`)
+      : Promise.resolve(null),
+    item.posterUrl
+      ? mirrorToBlob(item.posterUrl, `case-studies/${item.id}/poster.jpg`)
+      : Promise.resolve(null),
+  ]);
+
+  const isVideo = videoUrl !== null;
+
+  const coverImageUrl =
+    !isVideo && item.websiteUrl
+      ? await fetchScreenshotUrl(item.websiteUrl)
+      : null;
+
+  const aiSummary = await generateSummary({
+    name: item.name,
+    url: item.websiteUrl,
+    sourceText: item.sourceText,
+    types: item.types,
+    industries: item.industries,
+  });
+
+  await db
+    .update(caseStudies)
+    .set({
+      mediaType: isVideo ? "video" : "website",
+      videoUrl,
+      posterUrl,
+      ...(coverImageUrl
+        ? { coverImageUrl, coverImageLastFetchedAt: new Date() }
+        : {}),
+      ...(aiSummary ? { aiSummary, aiSummaryGeneratedAt: new Date() } : {}),
+    })
+    .where(eq(caseStudies.id, item.id));
+}
+
+/** True when anything the enrichment step depends on has changed. */
+function needsEnrichment(item: NotionCaseStudy, dbItem: DbCaseStudy) {
+  return (
+    dbItem.websiteUrl !== item.websiteUrl ||
+    dbItem.sourceText !== item.sourceText ||
+    // Notion holds the upstream URL; the DB holds the mirrored Blob URL, so
+    // compare on presence rather than equality.
+    (item.videoUrl !== null) !== (dbItem.videoUrl !== null) ||
+    (item.posterUrl !== null) !== (dbItem.posterUrl !== null) ||
+    dbItem.aiSummary === null
+  );
+}
+
+export async function GET() {
+  const trueItems = await fetchCaseStudyData();
+  const dbItems = await db.query.caseStudies.findMany();
+
+  const newItems = trueItems.filter(
+    (item) => !dbItems.some((dbItem) => dbItem.id === item.id),
+  );
+  const existingItems = trueItems.filter((item) =>
+    dbItems.some((dbItem) => dbItem.id === item.id),
+  );
+  const deletedItems = dbItems.filter(
+    (dbItem) => !trueItems.some((item) => item.id === dbItem.id),
+  );
+
+  const writes: Promise<unknown>[] = [];
+
+  if (newItems.length > 0) {
+    writes.push(
+      db.insert(caseStudies).values(
+        newItems.map((item) => ({
+          id: item.id,
+          name: item.name,
+          websiteUrl: item.websiteUrl,
+          createdAt: new Date(item.createdAt),
+          updatedAt: new Date(item.updatedAt),
+          types: item.types,
+          industries: item.industries,
+          infoRole: item.infoRole,
+          infoTeam: item.infoTeam,
+          sourceText: item.sourceText,
+        })),
+      ),
+    );
+  }
+
+  writes.push(
+    ...existingItems.map((item) =>
+      db
+        .update(caseStudies)
+        .set({
+          name: item.name,
+          websiteUrl: item.websiteUrl,
+          updatedAt: new Date(item.updatedAt),
+          types: item.types,
+          industries: item.industries,
+          infoRole: item.infoRole,
+          infoTeam: item.infoTeam,
+          sourceText: item.sourceText,
+        })
+        .where(eq(caseStudies.id, item.id)),
+    ),
+  );
+
+  if (deletedItems.length > 0) {
+    writes.push(
+      db.delete(caseStudies).where(
+        inArray(
+          caseStudies.id,
+          deletedItems.map((item) => item.id),
+        ),
+      ),
+    );
+  }
+
+  await Promise.all(writes);
+
+  const cleanedUp = await cleanupOrphanedIndustries(trueItems);
+
+  // Only re-derive media and summaries where the inputs actually moved —
+  // screenshots and model calls are the expensive part of this route.
+  const staleItems = existingItems.filter((item) => {
+    const dbItem = dbItems.find((row) => row.id === item.id);
+    return dbItem ? needsEnrichment(item, dbItem) : false;
+  });
+
+  const itemsToEnrich = [...newItems, ...staleItems];
+  await Promise.all(itemsToEnrich.map(enrichCaseStudy));
+
+  return NextResponse.json({
+    newItems: newItems.length,
+    updatedItems: existingItems.length,
+    deletedItems: deletedItems.length,
+    cleanedUpIndustries: cleanedUp,
+    enrichedItems: itemsToEnrich.length,
+  });
+}

--- a/src/app/api/case-study-sync/route.ts
+++ b/src/app/api/case-study-sync/route.ts
@@ -101,6 +101,19 @@ function needsEnrichment(item: NotionCaseStudy, dbItem: DbCaseStudy) {
 }
 
 export async function GET() {
+  // The daily cron runs whether or not case studies have been set up yet, so
+  // treat missing credentials as "nothing to do" rather than an error.
+  if (!process.env.NOTION_CASE_STUDY_DATABASE_ID || !process.env.NOTION_API_KEY) {
+    return NextResponse.json({
+      skipped: "case study sync is not configured",
+      missing: [
+        !process.env.NOTION_CASE_STUDY_DATABASE_ID &&
+          "NOTION_CASE_STUDY_DATABASE_ID",
+        !process.env.NOTION_API_KEY && "NOTION_API_KEY",
+      ].filter(Boolean),
+    });
+  }
+
   const trueItems = await fetchCaseStudyData();
   const dbItems = await db.query.caseStudies.findMany();
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,12 +2,67 @@ import { api, HydrateClient } from "@/trpc/server";
 import { DesktopNav } from "@/components/nav/desktop-nav";
 import { MobileNav } from "@/components/nav/mobile-nav";
 import CollectableGrid from "@/components/collectable-grid";
+import CaseStudyGrid from "@/components/case-study-grid";
 
 const COLLECTABLE_PER_PAGE = 12;
 
-export default async function Home() {
-  const allTags = await api.collectable.getUniqueTags();
-  const allTypes = await api.collectable.getUniqueTypes();
+interface HomeProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function Home({ searchParams }: HomeProps) {
+  const { view } = await searchParams;
+  const isCaseStudyView = view === "case-study";
+
+  const [allTags, allTypes, caseStudyTypes, caseStudyIndustries] =
+    await Promise.all([
+      api.collectable.getUniqueTags(),
+      api.collectable.getUniqueTypes(),
+      api.caseStudy.getUniqueTypes(),
+      api.caseStudy.getUniqueIndustries(),
+    ]);
+
+  const nav = (
+    <>
+      {/* Desktop Navigation */}
+      <DesktopNav
+        tagOptions={allTags}
+        typeOptions={allTypes}
+        caseStudyTypeOptions={caseStudyTypes}
+        caseStudyIndustryOptions={caseStudyIndustries}
+      />
+
+      {/* Mobile Navigation */}
+      <div className="block md:hidden">
+        <MobileNav
+          tagOptions={allTags}
+          typeOptions={allTypes}
+          caseStudyTypeOptions={caseStudyTypes}
+          caseStudyIndustryOptions={caseStudyIndustries}
+        />
+      </div>
+    </>
+  );
+
+  if (isCaseStudyView) {
+    const initialCaseStudies = await api.caseStudy.getInfiniteScroll({
+      types: [],
+      industries: [],
+      limit: COLLECTABLE_PER_PAGE,
+    });
+
+    return (
+      <HydrateClient>
+        {nav}
+        <main className="container mx-auto px-4 pb-32 pt-20 md:pb-8 md:pt-8">
+          <CaseStudyGrid
+            initialData={initialCaseStudies}
+            pageSize={COLLECTABLE_PER_PAGE}
+          />
+        </main>
+      </HydrateClient>
+    );
+  }
 
   const initialInfiniteScrollData = await api.collectable.getInfiniteScroll({
     type: undefined,
@@ -17,15 +72,8 @@ export default async function Home() {
 
   return (
     <HydrateClient>
-      {/* Desktop Navigation */}
-      <DesktopNav tagOptions={allTags} typeOptions={allTypes} />
-
-      {/* Mobile Navigation */}
-      <div className="block md:hidden">
-        <MobileNav tagOptions={allTags} typeOptions={allTypes} />
-      </div>
-
-      <main className="container mx-auto px-4 pt-20 pb-32 md:pt-8 md:pb-8">
+      {nav}
+      <main className="container mx-auto px-4 pb-32 pt-20 md:pb-8 md:pt-8">
         <CollectableGrid
           initialData={initialInfiniteScrollData}
           pageSize={COLLECTABLE_PER_PAGE}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,13 +14,21 @@ export default async function Home({ searchParams }: HomeProps) {
   const { view } = await searchParams;
   const isCaseStudyView = view === "case-study";
 
-  const [allTags, allTypes, caseStudyTypes, caseStudyIndustries] =
-    await Promise.all([
-      api.collectable.getUniqueTags(),
-      api.collectable.getUniqueTypes(),
-      api.caseStudy.getUniqueTypes(),
-      api.caseStudy.getUniqueIndustries(),
-    ]);
+  const [allTags, allTypes] = await Promise.all([
+    api.collectable.getUniqueTags(),
+    api.collectable.getUniqueTypes(),
+  ]);
+
+  // Only read the case study tables when that view is actually being shown.
+  // Switching views is a full server round trip (the `view` param is not
+  // shallow), so the real options are fetched before the filters are visible —
+  // and the designer view stays up even if the case study table is absent.
+  const [caseStudyTypes, caseStudyIndustries] = isCaseStudyView
+    ? await Promise.all([
+        api.caseStudy.getUniqueTypes(),
+        api.caseStudy.getUniqueIndustries(),
+      ])
+    : [[], []];
 
   const nav = (
     <>

--- a/src/components/case-study-card.tsx
+++ b/src/components/case-study-card.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
+import { type api as serverApi } from "@/trpc/server";
+import { cn } from "@/lib/utils";
+import { ImagePlaceholder } from "./image-placeholder";
+
+type CaseStudy = Awaited<
+  ReturnType<(typeof serverApi)["caseStudy"]["getInfiniteScroll"]>
+>["items"][number];
+
+interface CaseStudyCardProps {
+  caseStudy: CaseStudy;
+}
+
+function prefersReducedMotion() {
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+function toTitleCase(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+export function CaseStudyCard({ caseStudy }: CaseStudyCardProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [mediaError, setMediaError] = useState(false);
+
+  const hasVideo =
+    caseStudy.mediaType === "video" && caseStudy.videoUrl !== null && !mediaError;
+
+  // On touch devices there is no hover, so play whichever card is on screen.
+  useEffect(() => {
+    const video = videoRef.current;
+    const container = containerRef.current;
+    if (!hasVideo || !video || !container) return;
+    if (window.matchMedia("(hover: hover)").matches) return;
+    if (prefersReducedMotion()) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          void video.play().catch(() => undefined);
+        } else {
+          video.pause();
+        }
+      },
+      { threshold: 0.6 },
+    );
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [hasVideo]);
+
+  const handleMouseEnter = () => {
+    if (!hasVideo || prefersReducedMotion()) return;
+    void videoRef.current?.play().catch(() => undefined);
+  };
+
+  const handleMouseLeave = () => {
+    const video = videoRef.current;
+    if (!hasVideo || !video) return;
+    video.pause();
+    video.currentTime = 0;
+  };
+
+  const media = hasVideo ? (
+    <video
+      ref={videoRef}
+      src={caseStudy.videoUrl!}
+      poster={caseStudy.posterUrl ?? undefined}
+      muted
+      loop
+      playsInline
+      preload="metadata"
+      className="h-full w-full object-cover"
+      onError={() => setMediaError(true)}
+    />
+  ) : caseStudy.coverImageUrl && !mediaError ? (
+    <Image
+      src={caseStudy.coverImageUrl}
+      alt={caseStudy.name}
+      fill
+      unoptimized
+      className="object-cover"
+      onError={() => setMediaError(true)}
+    />
+  ) : (
+    <ImagePlaceholder name={caseStudy.name} fill />
+  );
+
+  const metadata = [caseStudy.infoRole, caseStudy.infoTeam].filter(Boolean);
+
+  return (
+    <div
+      ref={containerRef}
+      className="group relative block"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <div className="relative aspect-video overflow-hidden rounded-sm bg-muted">
+        {media}
+
+        {caseStudy.websiteUrl && (
+          <a
+            href={caseStudy.websiteUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="absolute inset-0 z-10"
+            aria-label={`Visit ${caseStudy.name}`}
+          />
+        )}
+
+        {caseStudy.industries && caseStudy.industries.length > 0 && (
+          <div className="pointer-events-none absolute bottom-3 left-3 z-20 flex flex-wrap gap-1.5">
+            {caseStudy.industries.map((industry) => (
+              <span
+                key={industry}
+                className="rounded-full bg-white px-2 py-0.5 text-xs font-medium text-neutral-700"
+              >
+                {toTitleCase(industry)}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="mt-3 flex flex-col gap-1.5">
+        {caseStudy.websiteUrl ? (
+          <a
+            href={caseStudy.websiteUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="cursor-pointer"
+          >
+            <h2 className="font-medium text-neutral-900">{caseStudy.name}</h2>
+          </a>
+        ) : (
+          <h2 className="font-medium text-neutral-900">{caseStudy.name}</h2>
+        )}
+
+        {caseStudy.aiSummary && (
+          <p className="text-sm leading-snug text-neutral-600">
+            {caseStudy.aiSummary}
+          </p>
+        )}
+
+        {metadata.length > 0 && (
+          <p className={cn("text-xs text-neutral-500")}>
+            {metadata.join(" · ")}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/case-study-grid.tsx
+++ b/src/components/case-study-grid.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { api } from "@/trpc/react";
+import type { api as serverApi } from "@/trpc/server";
+import { useMemo } from "react";
+import InfiniteScroll from "react-infinite-scroll-component";
+import { motion } from "motion/react";
+
+import {
+  hasAnyCaseStudyFilterApplied,
+  useCaseStudyFilterParams,
+} from "@/hooks/params-parsers/use-case-study-filter-params";
+import { CaseStudyCard } from "./case-study-card";
+import BilliardBall from "./billiard-ball";
+
+interface CaseStudyGridProps {
+  initialData: Awaited<
+    ReturnType<(typeof serverApi)["caseStudy"]["getInfiniteScroll"]>
+  >;
+  pageSize: number;
+}
+
+function CaseStudyGrid({ initialData, pageSize }: CaseStudyGridProps) {
+  const [filterParams] = useCaseStudyFilterParams();
+
+  const hasFilter = hasAnyCaseStudyFilterApplied(filterParams);
+
+  const infiniteCaseStudies = api.caseStudy.getInfiniteScroll.useInfiniteQuery(
+    {
+      limit: pageSize,
+      types: filterParams.types,
+      industries: filterParams.industries,
+    },
+    {
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+      refetchOnWindowFocus: false,
+
+      initialData: hasFilter
+        ? undefined
+        : {
+            pages: [initialData],
+            pageParams: [undefined],
+          },
+    },
+  );
+
+  const allItems = useMemo(() => {
+    return infiniteCaseStudies.data?.pages.flatMap((page) => page.items);
+  }, [infiniteCaseStudies.data]);
+
+  return (
+    <>
+      {infiniteCaseStudies.isLoading && (
+        <div className="flex h-[calc(100vh-32rem)] items-center justify-center">
+          <BilliardBall className="" spin />
+        </div>
+      )}
+
+      {!infiniteCaseStudies.isLoading && allItems?.length > 0 && (
+        <InfiniteScroll
+          className="pb-24 md:pb-24"
+          dataLength={infiniteCaseStudies.data?.pages.length ?? 0}
+          next={infiniteCaseStudies.fetchNextPage}
+          hasMore={infiniteCaseStudies.hasNextPage || false}
+          scrollableTarget="scrollableDiv"
+          style={{ overflow: "visible" }}
+          loader={
+            <div className="flex items-center justify-center">
+              <BilliardBall className="mt-12" spin />
+            </div>
+          }
+        >
+          <div className="grid grid-cols-1 gap-x-6 gap-y-10 md:grid-cols-2 lg:grid-cols-3">
+            {allItems?.map((item, i) => (
+              <motion.div
+                key={item.id}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5, delay: (i % pageSize) * 0.1 }}
+              >
+                <CaseStudyCard caseStudy={item} />
+              </motion.div>
+            ))}
+          </div>
+        </InfiniteScroll>
+      )}
+
+      {!infiniteCaseStudies.isLoading && allItems?.length === 0 && (
+        <div className="flex h-[calc(100vh-32rem)] flex-col items-center justify-center gap-4">
+          <BilliardBall className="" ballType="8-ball" />
+          <p className="text-2xl">No case studies yet</p>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default CaseStudyGrid;

--- a/src/components/case-study-grid.tsx
+++ b/src/components/case-study-grid.tsx
@@ -88,7 +88,7 @@ function CaseStudyGrid({ initialData, pageSize }: CaseStudyGridProps) {
       {!infiniteCaseStudies.isLoading && allItems?.length === 0 && (
         <div className="flex h-[calc(100vh-32rem)] flex-col items-center justify-center gap-4">
           <BilliardBall className="" ballType="8-ball" />
-          <p className="text-2xl">No case studies yet</p>
+          <p className="text-2xl">No projects yet</p>
         </div>
       )}
     </>

--- a/src/components/image-placeholder.tsx
+++ b/src/components/image-placeholder.tsx
@@ -1,6 +1,12 @@
 interface ImagePlaceholderProps {
   name: string;
   className?: string;
+  /**
+   * Stretch the colour block to the whole frame instead of insetting a 2:1
+   * swatch. Used by the landscape case study cards; the square designer cards
+   * keep the inset look.
+   */
+  fill?: boolean;
 }
 
 // Expanded Bauhaus and Swiss style inspired color palette
@@ -31,7 +37,11 @@ const bauhausColors = [
   "#E9C46A", // Saffron
 ];
 
-export function ImagePlaceholder({ name, className }: ImagePlaceholderProps) {
+export function ImagePlaceholder({
+  name,
+  className,
+  fill = false,
+}: ImagePlaceholderProps) {
   // Get initials from name (up to 2 characters)
   const initials = name
     .split(/[^a-zA-Z]/)
@@ -52,6 +62,17 @@ export function ImagePlaceholder({ name, className }: ImagePlaceholderProps) {
   const colorStyle = {
     backgroundColor: backgroundColor,
   };
+
+  if (fill) {
+    return (
+      <div
+        className={`flex h-full w-full items-center justify-center ${className ?? ""}`}
+        style={colorStyle}
+      >
+        <span className="text-4xl font-medium text-white">{initials}</span>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/components/nav/case-study-filter.tsx
+++ b/src/components/nav/case-study-filter.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { ArrowCounterClockwise, CaretDown } from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
+import { useCaseStudyFilterParams } from "@/hooks/params-parsers/use-case-study-filter-params";
+import { useMemo, useState } from "react";
+import { DropdownMenu } from "@/components/ui/dropdown-menu";
+import { motion } from "motion/react";
+
+interface CaseStudyFilterProps {
+  typeOptions: string[];
+  industryOptions: string[];
+}
+
+function toTitleCase(str: string) {
+  return str.replace(
+    /\w\S*/g,
+    (txt) => txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase(),
+  );
+}
+
+/** "All X" until something is picked, then up to two values and a +n overflow. */
+function buildLabel(selected: string[], emptyLabel: string) {
+  if (selected.length === 0) return emptyLabel;
+
+  const shown = selected.slice(0, 2).map(toTitleCase);
+  const extra = selected.length - 2;
+
+  return extra > 0 ? `${shown.join(", ")}, and ${extra}+` : shown.join(", ");
+}
+
+export function CaseStudyFilter({
+  typeOptions,
+  industryOptions,
+}: CaseStudyFilterProps) {
+  const [params, setParams] = useCaseStudyFilterParams();
+  const { types: selectedTypes, industries: selectedIndustries } = params;
+
+  const [typeOpen, setTypeOpen] = useState(false);
+  const [industryOpen, setIndustryOpen] = useState(false);
+
+  const hasAnySelection = useMemo(
+    () => selectedTypes.length > 0 || selectedIndustries.length > 0,
+    [selectedTypes, selectedIndustries],
+  );
+
+  const toggle = (key: "types" | "industries", value: string) => {
+    const current = params[key];
+    void setParams({
+      ...params,
+      [key]: current.includes(value)
+        ? current.filter((entry) => entry !== value)
+        : [...current, value],
+    });
+  };
+
+  const triggerClasses = (isOpen: boolean) =>
+    cn(
+      "flex items-center gap-2 rounded-full px-4 py-2 text-sm font-normal transition-colors focus:outline-none",
+      isOpen
+        ? "bg-black text-white"
+        : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
+    );
+
+  return (
+    <div className="flex items-center gap-2 pb-0 pt-0">
+      <DropdownMenu.Root open={typeOpen} onOpenChange={setTypeOpen}>
+        <DropdownMenu.Trigger asChild>
+          <button className={triggerClasses(typeOpen)} style={{ maxWidth: 240 }}>
+            <span className="max-w-[240px] truncate">
+              {buildLabel(selectedTypes, "All Types")}
+            </span>
+            <motion.div
+              animate={{ rotate: typeOpen ? 360 : 270 }}
+              transition={{ duration: 0.2, ease: "easeInOut" }}
+              className="flex-shrink-0"
+            >
+              <CaretDown weight="fill" className="h-4 w-4" />
+            </motion.div>
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content open={typeOpen}>
+          {typeOptions.map((type) => (
+            <DropdownMenu.Item
+              key={type}
+              onSelect={(e) => {
+                e.preventDefault();
+                toggle("types", type);
+              }}
+              selected={selectedTypes.includes(type)}
+            >
+              {toTitleCase(type)}
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+
+      <DropdownMenu.Root open={industryOpen} onOpenChange={setIndustryOpen}>
+        <DropdownMenu.Trigger asChild>
+          <button
+            className={triggerClasses(industryOpen)}
+            style={{ maxWidth: 240 }}
+          >
+            <span className="max-w-[240px] truncate">
+              {buildLabel(selectedIndustries, "All Industries")}
+            </span>
+            <motion.div
+              animate={{ rotate: industryOpen ? 360 : 270 }}
+              transition={{ duration: 0.2, ease: "easeInOut" }}
+              className="flex-shrink-0"
+            >
+              <CaretDown weight="fill" className="h-4 w-4" />
+            </motion.div>
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content open={industryOpen}>
+          {industryOptions.map((industry) => (
+            <DropdownMenu.Item
+              key={industry}
+              onSelect={(e) => {
+                e.preventDefault();
+                toggle("industries", industry);
+              }}
+              selected={selectedIndustries.includes(industry)}
+            >
+              {toTitleCase(industry)}
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+
+      <button
+        onClick={() => setParams({ ...params, types: [], industries: [] })}
+        className={cn(
+          "flex h-9 w-9 items-center justify-center rounded-full bg-neutral-200 text-neutral-900 transition-all hover:bg-neutral-300",
+          !hasAnySelection && "pointer-events-none opacity-0",
+        )}
+        aria-label="Reset filters"
+      >
+        <motion.span
+          whileHover={{ rotate: -60 }}
+          transition={{ duration: 0.2, ease: "easeInOut" }}
+          style={{ display: "inline-flex" }}
+        >
+          <ArrowCounterClockwise weight="fill" className="h-5 w-5" />
+        </motion.span>
+      </button>
+    </div>
+  );
+}

--- a/src/components/nav/case-study-filter.tsx
+++ b/src/components/nav/case-study-filter.tsx
@@ -140,22 +140,23 @@ export function CaseStudyFilter({
         </DropdownMenu.Root>
       )}
 
-      <button
-        onClick={() => setParams({ ...params, types: [], industries: [] })}
-        className={cn(
-          "flex h-9 w-9 items-center justify-center rounded-full bg-neutral-200 text-neutral-900 transition-all hover:bg-neutral-300",
-          !hasAnySelection && "pointer-events-none opacity-0",
-        )}
-        aria-label="Reset filters"
-      >
-        <motion.span
-          whileHover={{ rotate: -60 }}
-          transition={{ duration: 0.2, ease: "easeInOut" }}
-          style={{ display: "inline-flex" }}
+      {/* Only takes up space once there's something to reset — the header
+          column is narrow enough that the idle 36px matters. */}
+      {hasAnySelection && (
+        <button
+          onClick={() => setParams({ ...params, types: [], industries: [] })}
+          className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-neutral-200 text-neutral-900 transition-all hover:bg-neutral-300"
+          aria-label="Reset filters"
         >
-          <ArrowCounterClockwise weight="fill" className="h-5 w-5" />
-        </motion.span>
-      </button>
+          <motion.span
+            whileHover={{ rotate: -60 }}
+            transition={{ duration: 0.2, ease: "easeInOut" }}
+            style={{ display: "inline-flex" }}
+          >
+            <ArrowCounterClockwise weight="fill" className="h-5 w-5" />
+          </motion.span>
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/nav/case-study-filter.tsx
+++ b/src/components/nav/case-study-filter.tsx
@@ -56,78 +56,89 @@ export function CaseStudyFilter({
 
   const triggerClasses = (isOpen: boolean) =>
     cn(
-      "flex items-center gap-2 rounded-full px-4 py-2 text-sm font-normal transition-colors focus:outline-none",
+      "flex h-9 items-center gap-2 rounded-full px-4 text-sm font-normal transition-colors focus:outline-none",
       isOpen
         ? "bg-black text-white"
         : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
     );
 
+  // An empty database means empty dropdowns — show nothing rather than
+  // controls that can't do anything.
+  if (typeOptions.length === 0 && industryOptions.length === 0) return null;
+
   return (
     <div className="flex items-center gap-2 pb-0 pt-0">
-      <DropdownMenu.Root open={typeOpen} onOpenChange={setTypeOpen}>
-        <DropdownMenu.Trigger asChild>
-          <button className={triggerClasses(typeOpen)} style={{ maxWidth: 240 }}>
-            <span className="max-w-[240px] truncate">
-              {buildLabel(selectedTypes, "All Types")}
-            </span>
-            <motion.div
-              animate={{ rotate: typeOpen ? 360 : 270 }}
-              transition={{ duration: 0.2, ease: "easeInOut" }}
-              className="flex-shrink-0"
+      {typeOptions.length > 0 && (
+        <DropdownMenu.Root open={typeOpen} onOpenChange={setTypeOpen}>
+          <DropdownMenu.Trigger asChild>
+            <button
+              className={triggerClasses(typeOpen)}
+              style={{ maxWidth: 240 }}
             >
-              <CaretDown weight="fill" className="h-4 w-4" />
-            </motion.div>
-          </button>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Content open={typeOpen}>
-          {typeOptions.map((type) => (
-            <DropdownMenu.Item
-              key={type}
-              onSelect={(e) => {
-                e.preventDefault();
-                toggle("types", type);
-              }}
-              selected={selectedTypes.includes(type)}
-            >
-              {toTitleCase(type)}
-            </DropdownMenu.Item>
-          ))}
-        </DropdownMenu.Content>
-      </DropdownMenu.Root>
+              <span className="max-w-[240px] truncate">
+                {buildLabel(selectedTypes, "All Types")}
+              </span>
+              <motion.div
+                animate={{ rotate: typeOpen ? 360 : 270 }}
+                transition={{ duration: 0.2, ease: "easeInOut" }}
+                className="flex-shrink-0"
+              >
+                <CaretDown weight="fill" className="h-4 w-4" />
+              </motion.div>
+            </button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content open={typeOpen}>
+            {typeOptions.map((type) => (
+              <DropdownMenu.Item
+                key={type}
+                onSelect={(e) => {
+                  e.preventDefault();
+                  toggle("types", type);
+                }}
+                selected={selectedTypes.includes(type)}
+              >
+                {toTitleCase(type)}
+              </DropdownMenu.Item>
+            ))}
+          </DropdownMenu.Content>
+        </DropdownMenu.Root>
+      )}
 
-      <DropdownMenu.Root open={industryOpen} onOpenChange={setIndustryOpen}>
-        <DropdownMenu.Trigger asChild>
-          <button
-            className={triggerClasses(industryOpen)}
-            style={{ maxWidth: 240 }}
-          >
-            <span className="max-w-[240px] truncate">
-              {buildLabel(selectedIndustries, "All Industries")}
-            </span>
-            <motion.div
-              animate={{ rotate: industryOpen ? 360 : 270 }}
-              transition={{ duration: 0.2, ease: "easeInOut" }}
-              className="flex-shrink-0"
+      {industryOptions.length > 0 && (
+        <DropdownMenu.Root open={industryOpen} onOpenChange={setIndustryOpen}>
+          <DropdownMenu.Trigger asChild>
+            <button
+              className={triggerClasses(industryOpen)}
+              style={{ maxWidth: 240 }}
             >
-              <CaretDown weight="fill" className="h-4 w-4" />
-            </motion.div>
-          </button>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Content open={industryOpen}>
-          {industryOptions.map((industry) => (
-            <DropdownMenu.Item
-              key={industry}
-              onSelect={(e) => {
-                e.preventDefault();
-                toggle("industries", industry);
-              }}
-              selected={selectedIndustries.includes(industry)}
-            >
-              {toTitleCase(industry)}
-            </DropdownMenu.Item>
-          ))}
-        </DropdownMenu.Content>
-      </DropdownMenu.Root>
+              <span className="max-w-[240px] truncate">
+                {buildLabel(selectedIndustries, "All Industries")}
+              </span>
+              <motion.div
+                animate={{ rotate: industryOpen ? 360 : 270 }}
+                transition={{ duration: 0.2, ease: "easeInOut" }}
+                className="flex-shrink-0"
+              >
+                <CaretDown weight="fill" className="h-4 w-4" />
+              </motion.div>
+            </button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content open={industryOpen}>
+            {industryOptions.map((industry) => (
+              <DropdownMenu.Item
+                key={industry}
+                onSelect={(e) => {
+                  e.preventDefault();
+                  toggle("industries", industry);
+                }}
+                selected={selectedIndustries.includes(industry)}
+              >
+                {toTitleCase(industry)}
+              </DropdownMenu.Item>
+            ))}
+          </DropdownMenu.Content>
+        </DropdownMenu.Root>
+      )}
 
       <button
         onClick={() => setParams({ ...params, types: [], industries: [] })}

--- a/src/components/nav/desktop-nav.tsx
+++ b/src/components/nav/desktop-nav.tsx
@@ -55,11 +55,12 @@ export function DesktopNav({
         <div className="container mx-auto px-4 pb-4 md:px-6 md:pb-6 lg:px-8">
           <div className="flex flex-col gap-3 md:gap-4">
             {/* Mobile and Desktop: 3-column layout */}
-            <div className="hidden flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-4 lg:flex lg:gap-6">
-              {/* Left: spacer that keeps the logo optically centred. The
-                  controls need more room than this column can give, so they
-                  get their own full-width row below. */}
-              <div className="md:flex-1" />
+            <div className="hidden flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-4 lg:flex lg:gap-6">
+              {/* Left: controls, top-aligned with the logo and the text */}
+              <div className="flex flex-wrap items-center gap-2 md:flex-1">
+                <ViewToggle />
+                {filters}
+              </div>
               {/* Center: Logo */}
               <div className="flex justify-center md:w-[160px] md:flex-shrink-0 md:items-center md:justify-center lg:w-[200px]">
                 <div className="relative flex h-full items-center justify-center">
@@ -100,13 +101,6 @@ export function DesktopNav({
                   </button>
                 </p>
               </div>
-            </div>
-
-            {/* Desktop: controls get the full container width so the toggle
-                and both filters sit on one line. */}
-            <div className="hidden items-center gap-2 lg:flex">
-              <ViewToggle />
-              {filters}
             </div>
 
             {/* Tablet: 2-column layout with left content and right logo */}

--- a/src/components/nav/desktop-nav.tsx
+++ b/src/components/nav/desktop-nav.tsx
@@ -6,16 +6,37 @@ import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
 import { SubmissionForm } from "../submission-form";
+import { useViewParams } from "@/hooks/params-parsers/use-view-params";
+import { ViewToggle } from "./view-toggle";
+import { CaseStudyFilter } from "./case-study-filter";
 
 const manrope = Manrope({ subsets: ["latin"] });
 
 interface DesktopNavProps {
   typeOptions: string[];
   tagOptions: string[];
+  caseStudyTypeOptions: string[];
+  caseStudyIndustryOptions: string[];
 }
 
-export function DesktopNav({ typeOptions, tagOptions }: DesktopNavProps) {
+export function DesktopNav({
+  typeOptions,
+  tagOptions,
+  caseStudyTypeOptions,
+  caseStudyIndustryOptions,
+}: DesktopNavProps) {
   const [isFormOpen, setIsFormOpen] = useState(false);
+  const [{ view }] = useViewParams();
+
+  const filters =
+    view === "case-study" ? (
+      <CaseStudyFilter
+        typeOptions={caseStudyTypeOptions}
+        industryOptions={caseStudyIndustryOptions}
+      />
+    ) : (
+      <HorizontalFilter tagOptions={tagOptions} typeOptions={typeOptions} />
+    );
 
   return (
     <>
@@ -36,8 +57,9 @@ export function DesktopNav({ typeOptions, tagOptions }: DesktopNavProps) {
             {/* Mobile and Desktop: 3-column layout */}
             <div className="hidden lg:flex flex-col gap-3 md:gap-4 lg:gap-6 md:flex-row md:items-center md:justify-between">
               {/* Left: Filters */}
-              <div className="flex justify-start md:flex-1 md:justify-start">
-                <HorizontalFilter tagOptions={tagOptions} typeOptions={typeOptions} />
+              <div className="flex flex-col items-start gap-3 md:flex-1">
+                <ViewToggle />
+                {filters}
               </div>
               {/* Center: Logo */}
               <div className="flex justify-center md:w-[160px] lg:w-[200px] md:flex-shrink-0 md:items-center md:justify-center">
@@ -108,8 +130,9 @@ export function DesktopNav({ typeOptions, tagOptions }: DesktopNavProps) {
                   </p>
                 </div>
                 {/* Filters */}
-                <div className="flex justify-start">
-                  <HorizontalFilter tagOptions={tagOptions} typeOptions={typeOptions} />
+                <div className="flex flex-col items-start gap-3">
+                  <ViewToggle />
+                  {filters}
                 </div>
               </div>
               

--- a/src/components/nav/desktop-nav.tsx
+++ b/src/components/nav/desktop-nav.tsx
@@ -41,7 +41,7 @@ export function DesktopNav({
   return (
     <>
       <header
-        className="hidden md:block sticky top-0 z-20 pt-6 md:pt-8 lg:pt-10 pb-6 md:pb-8 lg:pb-10"
+        className="sticky top-0 z-20 hidden pb-6 pt-6 md:block md:pb-8 md:pt-8 lg:pb-10 lg:pt-10"
         style={{
           backdropFilter: "blur(20px) brightness(1.1)",
           WebkitBackdropFilter: "blur(20px) brightness(1.1)",
@@ -52,17 +52,16 @@ export function DesktopNav({
           background: "linear-gradient(white 72%, transparent)",
         }}
       >
-        <div className="container mx-auto px-4 md:px-6 lg:px-8 pb-4 md:pb-6">
+        <div className="container mx-auto px-4 pb-4 md:px-6 md:pb-6 lg:px-8">
           <div className="flex flex-col gap-3 md:gap-4">
             {/* Mobile and Desktop: 3-column layout */}
-            <div className="hidden lg:flex flex-col gap-3 md:gap-4 lg:gap-6 md:flex-row md:items-center md:justify-between">
-              {/* Left: Filters */}
-              <div className="flex flex-col items-start gap-3 md:flex-1">
-                <ViewToggle />
-                {filters}
-              </div>
+            <div className="hidden flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-4 lg:flex lg:gap-6">
+              {/* Left: spacer that keeps the logo optically centred. The
+                  controls need more room than this column can give, so they
+                  get their own full-width row below. */}
+              <div className="md:flex-1" />
               {/* Center: Logo */}
-              <div className="flex justify-center md:w-[160px] lg:w-[200px] md:flex-shrink-0 md:items-center md:justify-center">
+              <div className="flex justify-center md:w-[160px] md:flex-shrink-0 md:items-center md:justify-center lg:w-[200px]">
                 <div className="relative flex h-full items-center justify-center">
                   <div className="relative h-[40px] w-[150px] md:h-[44px] md:w-[160px] lg:h-[48px] lg:w-[180px]">
                     <Image
@@ -76,8 +75,10 @@ export function DesktopNav({
                 </div>
               </div>
               {/* Right: Description/Links */}
-              <div className={`${manrope.className} mt-0 flex w-full flex-col items-end justify-center md:mt-0 md:flex-1 md:items-end md:justify-center`}>
-                <p className="text-sm md:text-base lg:text-l max-w-full text-right leading-tight text-neutral-700 md:max-w-[300px] lg:max-w-[400px]">
+              <div
+                className={`${manrope.className} mt-0 flex w-full flex-col items-end justify-center md:mt-0 md:flex-1 md:items-end md:justify-center`}
+              >
+                <p className="lg:text-l max-w-full text-right text-sm leading-tight text-neutral-700 md:max-w-[300px] md:text-base lg:max-w-[400px]">
                   Made by{" "}
                   <Link
                     href="https://x.com/notjerrywang"
@@ -88,26 +89,33 @@ export function DesktopNav({
                     @Jerry ↵
                   </Link>
                   <br />
-                  <span className="text-sm md:text-base lg:text-l leading-tight text-neutral-700">
+                  <span className="lg:text-l text-sm leading-tight text-neutral-700 md:text-base">
                     Have someone in mind?{" "}
                   </span>
                   <button
                     onClick={() => setIsFormOpen(true)}
-                    className="text-sm md:text-base lg:text-l leading-tight text-neutral-900 hover:underline"
+                    className="lg:text-l text-sm leading-tight text-neutral-900 hover:underline md:text-base"
                   >
-                     Submit a referral ↵
+                    Submit a referral ↵
                   </button>
                 </p>
               </div>
             </div>
 
+            {/* Desktop: controls get the full container width so the toggle
+                and both filters sit on one line. */}
+            <div className="hidden items-center gap-2 lg:flex">
+              <ViewToggle />
+              {filters}
+            </div>
+
             {/* Tablet: 2-column layout with left content and right logo */}
-            <div className="lg:hidden flex flex-col md:flex-row md:items-start md:justify-between">
+            <div className="flex flex-col md:flex-row md:items-start md:justify-between lg:hidden">
               {/* Left: Description and Filters stacked vertically */}
-              <div className="flex flex-col gap-3 md:gap-3 md:flex-1">
+              <div className="flex flex-col gap-3 md:flex-1 md:gap-3">
                 {/* Description text */}
                 <div className={`${manrope.className} flex flex-col`}>
-                  <p className="text-sm md:text-base lg:text-l max-w-full leading-tight text-neutral-700">
+                  <p className="lg:text-l max-w-full text-sm leading-tight text-neutral-700 md:text-base">
                     Made by{" "}
                     <Link
                       href="https://x.com/notjerrywang"
@@ -118,7 +126,7 @@ export function DesktopNav({
                       @Jerry ↵
                     </Link>
                     <br />
-                    <span className="text-sm md:text-base lg:text-l leading-tight text-neutral-700">
+                    <span className="lg:text-l text-sm leading-tight text-neutral-700 md:text-base">
                       Have someone in mind?{" "}
                       <button
                         onClick={() => setIsFormOpen(true)}
@@ -130,12 +138,12 @@ export function DesktopNav({
                   </p>
                 </div>
                 {/* Filters */}
-                <div className="flex flex-col items-start gap-3">
+                <div className="flex flex-wrap items-center gap-2">
                   <ViewToggle />
                   {filters}
                 </div>
               </div>
-              
+
               {/* Right: Logo */}
               <div className="flex justify-end md:flex-shrink-0 md:items-start">
                 <div className="relative flex h-full items-center justify-center">
@@ -154,11 +162,8 @@ export function DesktopNav({
           </div>
         </div>
       </header>
-      
-      <SubmissionForm 
-        open={isFormOpen} 
-        onOpenChange={setIsFormOpen} 
-      />
+
+      <SubmissionForm open={isFormOpen} onOpenChange={setIsFormOpen} />
     </>
   );
-} 
+}

--- a/src/components/nav/horizontal-filter.tsx
+++ b/src/components/nav/horizontal-filter.tsx
@@ -26,7 +26,10 @@ export function HorizontalFilter({
 
   // Helper for showing selected tags as comma-separated
   function toTitleCase(str: string) {
-    return str.replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase());
+    return str.replace(
+      /\w\S*/g,
+      (txt) => txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase(),
+    );
   }
 
   // Responsive expertise label: show up to 2, then '+x more'
@@ -40,11 +43,16 @@ export function HorizontalFilter({
       selectedTagsLabel = shown.join(", ");
     }
   }
-  const selectedTypeLabel = selectedType ? toTitleCase(selectedType) : "All Types";
+  const selectedTypeLabel = selectedType
+    ? toTitleCase(selectedType)
+    : "All Types";
 
   // Add state to track open status for each dropdown
   const [typeOpen, setTypeOpen] = useState(false);
   const [tagOpen, setTagOpen] = useState(false);
+
+  // Nothing to filter by — don't render controls that can't do anything.
+  if (typeOptions.length === 0 && tagOptions.length === 0) return null;
 
   return (
     <div className="flex items-center gap-2 pb-0 pt-0">
@@ -56,7 +64,7 @@ export function HorizontalFilter({
               "flex items-center gap-2 rounded-full px-4 py-2 text-sm font-normal transition-colors focus:outline-none",
               typeOpen
                 ? "bg-black text-white"
-                : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300"
+                : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
             )}
           >
             {selectedTypeLabel}
@@ -72,7 +80,12 @@ export function HorizontalFilter({
           {typeOptions.map((type) => (
             <DropdownMenu.Item
               key={type}
-              onSelect={() => void setParams({ ...params, type: selectedType === type ? null : type })}
+              onSelect={() =>
+                void setParams({
+                  ...params,
+                  type: selectedType === type ? null : type,
+                })
+              }
               selected={selectedType === type}
             >
               {toTitleCase(type)}
@@ -89,11 +102,11 @@ export function HorizontalFilter({
               "flex items-center gap-2 rounded-full px-4 py-2 text-sm font-normal transition-colors focus:outline-none",
               tagOpen
                 ? "bg-black text-white"
-                : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300"
+                : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
             )}
             style={{ maxWidth: 240 }}
           >
-            <span className="truncate max-w-[240px]">{selectedTagsLabel}</span>
+            <span className="max-w-[240px] truncate">{selectedTagsLabel}</span>
             <motion.div
               animate={{ rotate: tagOpen ? 360 : 270 }}
               transition={{ duration: 0.2, ease: "easeInOut" }}
@@ -109,12 +122,18 @@ export function HorizontalFilter({
             return (
               <DropdownMenu.Item
                 key={tag}
-                onSelect={e => {
+                onSelect={(e) => {
                   e.preventDefault(); // Prevent menu from closing
                   if (isSelected) {
-                    void setParams({ ...params, tags: selectedTags.filter((t) => t !== tag) });
+                    void setParams({
+                      ...params,
+                      tags: selectedTags.filter((t) => t !== tag),
+                    });
                   } else {
-                    void setParams({ ...params, tags: [...(selectedTags || []), tag] });
+                    void setParams({
+                      ...params,
+                      tags: [...(selectedTags || []), tag],
+                    });
                   }
                 }}
                 selected={isSelected}
@@ -131,7 +150,7 @@ export function HorizontalFilter({
         onClick={() => setParams({ ...params, type: null, tags: [] })}
         className={cn(
           "flex h-9 w-9 items-center justify-center rounded-full bg-neutral-200 text-neutral-900 transition-all hover:bg-neutral-300",
-          !hasAnySelection && "pointer-events-none opacity-0"
+          !hasAnySelection && "pointer-events-none opacity-0",
         )}
         aria-label="Reset filters"
       >

--- a/src/components/nav/horizontal-filter.tsx
+++ b/src/components/nav/horizontal-filter.tsx
@@ -145,23 +145,22 @@ export function HorizontalFilter({
         </DropdownMenu.Content>
       </DropdownMenu.Root>
 
-      {/* Reset button (moved to right of expertise dropdown) */}
-      <button
-        onClick={() => setParams({ ...params, type: null, tags: [] })}
-        className={cn(
-          "flex h-9 w-9 items-center justify-center rounded-full bg-neutral-200 text-neutral-900 transition-all hover:bg-neutral-300",
-          !hasAnySelection && "pointer-events-none opacity-0",
-        )}
-        aria-label="Reset filters"
-      >
-        <motion.span
-          whileHover={{ rotate: -60 }}
-          transition={{ duration: 0.2, ease: "easeInOut" }}
-          style={{ display: "inline-flex" }}
+      {/* Reset button — only occupies space once a filter is applied. */}
+      {hasAnySelection && (
+        <button
+          onClick={() => setParams({ ...params, type: null, tags: [] })}
+          className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-neutral-200 text-neutral-900 transition-all hover:bg-neutral-300"
+          aria-label="Reset filters"
         >
-          <ArrowCounterClockwise weight="fill" className="h-5 w-5" />
-        </motion.span>
-      </button>
+          <motion.span
+            whileHover={{ rotate: -60 }}
+            transition={{ duration: 0.2, ease: "easeInOut" }}
+            style={{ display: "inline-flex" }}
+          >
+            <ArrowCounterClockwise weight="fill" className="h-5 w-5" />
+          </motion.span>
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/nav/mobile-case-study-filter.tsx
+++ b/src/components/nav/mobile-case-study-filter.tsx
@@ -59,46 +59,55 @@ export function MobileCaseStudyFilter({
         : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
     );
 
+  // No options means an empty bottom bar — hide it entirely.
+  if (typeOptions.length === 0 && industryOptions.length === 0) return null;
+
   return (
     <>
       <div className="fixed bottom-0 left-0 right-0 z-50 bg-gradient-to-t from-white via-white via-[35%] to-transparent p-5">
         <div className="flex w-full flex-wrap items-center justify-center gap-2.5">
           <div className="flex items-center justify-center gap-2.5">
-            <button
-              onClick={() => setTypeOpen(true)}
-              className={triggerClasses(typeOpen)}
-            >
-              <span className="truncate">
-                {buildLabel(selectedTypes, "All Types")}
-              </span>
-              <motion.div
-                animate={{ rotate: typeOpen ? 180 : 0 }}
-                transition={{ duration: 0.2, ease: "easeInOut" }}
-                className="flex-shrink-0"
+            {typeOptions.length > 0 && (
+              <button
+                onClick={() => setTypeOpen(true)}
+                className={triggerClasses(typeOpen)}
               >
-                <CaretDown weight="fill" className="h-5 w-5" />
-              </motion.div>
-            </button>
+                <span className="truncate">
+                  {buildLabel(selectedTypes, "All Types")}
+                </span>
+                <motion.div
+                  animate={{ rotate: typeOpen ? 180 : 0 }}
+                  transition={{ duration: 0.2, ease: "easeInOut" }}
+                  className="flex-shrink-0"
+                >
+                  <CaretDown weight="fill" className="h-5 w-5" />
+                </motion.div>
+              </button>
+            )}
 
-            <button
-              onClick={() => setIndustryOpen(true)}
-              className={triggerClasses(industryOpen)}
-            >
-              <span className="truncate">
-                {buildLabel(selectedIndustries, "All Industries")}
-              </span>
-              <motion.div
-                animate={{ rotate: industryOpen ? 180 : 0 }}
-                transition={{ duration: 0.2, ease: "easeInOut" }}
-                className="flex-shrink-0"
+            {industryOptions.length > 0 && (
+              <button
+                onClick={() => setIndustryOpen(true)}
+                className={triggerClasses(industryOpen)}
               >
-                <CaretDown weight="fill" className="h-5 w-5" />
-              </motion.div>
-            </button>
+                <span className="truncate">
+                  {buildLabel(selectedIndustries, "All Industries")}
+                </span>
+                <motion.div
+                  animate={{ rotate: industryOpen ? 180 : 0 }}
+                  transition={{ duration: 0.2, ease: "easeInOut" }}
+                  className="flex-shrink-0"
+                >
+                  <CaretDown weight="fill" className="h-5 w-5" />
+                </motion.div>
+              </button>
+            )}
 
             {hasAnySelection && (
               <button
-                onClick={() => setParams({ ...params, types: [], industries: [] })}
+                onClick={() =>
+                  setParams({ ...params, types: [], industries: [] })
+                }
                 className="flex h-9 w-9 items-center justify-center rounded-full bg-neutral-200 p-2 text-neutral-900 transition-all hover:bg-neutral-300"
                 aria-label="Reset filters"
               >

--- a/src/components/nav/mobile-case-study-filter.tsx
+++ b/src/components/nav/mobile-case-study-filter.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { ArrowCounterClockwise, CaretDown } from "@phosphor-icons/react";
+import { useMemo, useState } from "react";
+import { motion } from "motion/react";
+import { cn } from "@/lib/utils";
+import { MobileDropdown } from "@/components/ui/mobile-dropdown";
+import { useCaseStudyFilterParams } from "@/hooks/params-parsers/use-case-study-filter-params";
+
+interface MobileCaseStudyFilterProps {
+  typeOptions: string[];
+  industryOptions: string[];
+}
+
+function toTitleCase(str: string) {
+  return str.replace(
+    /\w\S*/g,
+    (txt) => txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase(),
+  );
+}
+
+/** Tighter than the desktop label — one value plus a count, to fit the bar. */
+function buildLabel(selected: string[], emptyLabel: string) {
+  if (selected.length === 0) return emptyLabel;
+  if (selected.length === 1) return toTitleCase(selected[0] ?? "");
+  return `${toTitleCase(selected[0] ?? "")}, +${selected.length - 1}`;
+}
+
+export function MobileCaseStudyFilter({
+  typeOptions,
+  industryOptions,
+}: MobileCaseStudyFilterProps) {
+  const [params, setParams] = useCaseStudyFilterParams();
+  const { types: selectedTypes, industries: selectedIndustries } = params;
+
+  const [typeOpen, setTypeOpen] = useState(false);
+  const [industryOpen, setIndustryOpen] = useState(false);
+
+  const hasAnySelection = useMemo(
+    () => selectedTypes.length > 0 || selectedIndustries.length > 0,
+    [selectedTypes, selectedIndustries],
+  );
+
+  const toggle = (key: "types" | "industries", value: string) => {
+    const current = params[key];
+    void setParams({
+      ...params,
+      [key]: current.includes(value)
+        ? current.filter((entry) => entry !== value)
+        : [...current, value],
+    });
+  };
+
+  const triggerClasses = (isOpen: boolean) =>
+    cn(
+      "flex max-w-[160px] items-center gap-2 overflow-hidden text-ellipsis whitespace-nowrap rounded-full px-4 py-2 text-base font-normal transition-colors focus:outline-none",
+      isOpen
+        ? "bg-neutral-300 text-neutral-900"
+        : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
+    );
+
+  return (
+    <>
+      <div className="fixed bottom-0 left-0 right-0 z-50 bg-gradient-to-t from-white via-white via-[35%] to-transparent p-5">
+        <div className="flex w-full flex-wrap items-center justify-center gap-2.5">
+          <div className="flex items-center justify-center gap-2.5">
+            <button
+              onClick={() => setTypeOpen(true)}
+              className={triggerClasses(typeOpen)}
+            >
+              <span className="truncate">
+                {buildLabel(selectedTypes, "All Types")}
+              </span>
+              <motion.div
+                animate={{ rotate: typeOpen ? 180 : 0 }}
+                transition={{ duration: 0.2, ease: "easeInOut" }}
+                className="flex-shrink-0"
+              >
+                <CaretDown weight="fill" className="h-5 w-5" />
+              </motion.div>
+            </button>
+
+            <button
+              onClick={() => setIndustryOpen(true)}
+              className={triggerClasses(industryOpen)}
+            >
+              <span className="truncate">
+                {buildLabel(selectedIndustries, "All Industries")}
+              </span>
+              <motion.div
+                animate={{ rotate: industryOpen ? 180 : 0 }}
+                transition={{ duration: 0.2, ease: "easeInOut" }}
+                className="flex-shrink-0"
+              >
+                <CaretDown weight="fill" className="h-5 w-5" />
+              </motion.div>
+            </button>
+
+            {hasAnySelection && (
+              <button
+                onClick={() => setParams({ ...params, types: [], industries: [] })}
+                className="flex h-9 w-9 items-center justify-center rounded-full bg-neutral-200 p-2 text-neutral-900 transition-all hover:bg-neutral-300"
+                aria-label="Reset filters"
+              >
+                <motion.span
+                  whileHover={{ rotate: -60 }}
+                  transition={{ duration: 0.2, ease: "easeInOut" }}
+                  style={{ display: "inline-flex" }}
+                >
+                  <ArrowCounterClockwise weight="fill" className="h-5 w-5" />
+                </motion.span>
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <MobileDropdown
+        open={typeOpen}
+        onOpenChange={setTypeOpen}
+        options={typeOptions}
+        selectedOptions={selectedTypes}
+        onOptionSelect={(type) => toggle("types", type)}
+        multiSelect={true}
+      />
+
+      <MobileDropdown
+        open={industryOpen}
+        onOpenChange={setIndustryOpen}
+        options={industryOptions}
+        selectedOptions={selectedIndustries}
+        onOptionSelect={(industry) => toggle("industries", industry)}
+        multiSelect={true}
+      />
+    </>
+  );
+}

--- a/src/components/nav/mobile-nav.tsx
+++ b/src/components/nav/mobile-nav.tsx
@@ -9,13 +9,24 @@ import { motion, AnimatePresence } from "motion/react";
 import Image from "next/image";
 import Link from "next/link";
 import { SubmissionForm } from "@/components/submission-form";
+import { useViewParams } from "@/hooks/params-parsers/use-view-params";
+import { ViewToggle } from "./view-toggle";
+import { MobileCaseStudyFilter } from "./mobile-case-study-filter";
 
 interface MobileNavProps {
   tagOptions: string[];
   typeOptions: string[];
+  caseStudyTypeOptions: string[];
+  caseStudyIndustryOptions: string[];
 }
 
-export function MobileNav({ tagOptions, typeOptions }: MobileNavProps) {
+export function MobileNav({
+  tagOptions,
+  typeOptions,
+  caseStudyTypeOptions,
+  caseStudyIndustryOptions,
+}: MobileNavProps) {
+  const [{ view }] = useViewParams();
   const [params, setParams] = useCollectableFilterParams();
   const { type: selectedType, tags: selectedTags } = params;
   const [submissionFormOpen, setSubmissionFormOpen] = useState(false);
@@ -63,18 +74,34 @@ export function MobileNav({ tagOptions, typeOptions }: MobileNavProps) {
             />
           </div>
           
-          {/* Info Button */}
-          <button
-            onClick={() => setInfoOpen(true)}
-            className="flex items-center gap-2 rounded-full bg-neutral-200 px-4 py-2 text-base font-normal text-neutral-900 transition-colors hover:bg-neutral-300"
-          >
-            Info
-          </button>
+          <div className="flex items-center gap-2">
+            <ViewToggle />
+
+            {/* Info Button */}
+            <button
+              onClick={() => setInfoOpen(true)}
+              className="flex items-center gap-2 rounded-full bg-neutral-200 px-4 py-2 text-base font-normal text-neutral-900 transition-colors hover:bg-neutral-300"
+            >
+              Info
+            </button>
+          </div>
         </div>
       </div>
 
+      {view === "case-study" && (
+        <MobileCaseStudyFilter
+          typeOptions={caseStudyTypeOptions}
+          industryOptions={caseStudyIndustryOptions}
+        />
+      )}
+
       {/* Bottom Bar */}
-      <div className="fixed bottom-0 left-0 right-0 z-50 bg-gradient-to-t from-white via-white via-[35%] to-transparent p-5">
+      <div
+        className={cn(
+          "fixed bottom-0 left-0 right-0 z-50 bg-gradient-to-t from-white via-white via-[35%] to-transparent p-5",
+          view === "case-study" && "hidden",
+        )}
+      >
         <div className="flex flex-wrap items-center justify-center gap-2.5 w-full">
           <div className="flex items-center gap-2.5 justify-center">
             {/* Type Dropdown */}

--- a/src/components/nav/mobile-nav.tsx
+++ b/src/components/nav/mobile-nav.tsx
@@ -37,7 +37,10 @@ export function MobileNav({
 
   // Helper for showing selected tags as comma-separated
   function toTitleCase(str: string) {
-    return str.replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase());
+    return str.replace(
+      /\w\S*/g,
+      (txt) => txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase(),
+    );
   }
 
   // Improved expertise label: show first item + count for overflow
@@ -51,7 +54,9 @@ export function MobileNav({
       selectedTagsLabel = `${firstTag}, +${extraCount}`;
     }
   }
-  const selectedTypeLabel = selectedType ? toTitleCase(selectedType) : "All Types";
+  const selectedTypeLabel = selectedType
+    ? toTitleCase(selectedType)
+    : "All Types";
 
   // Add state to track open status for each dropdown
   const [typeOpen, setTypeOpen] = useState(false);
@@ -61,7 +66,7 @@ export function MobileNav({
   return (
     <>
       {/* Top Bar */}
-      <div className="fixed top-0 left-0 right-0 z-50 bg-gradient-to-b from-white from-[13%] via-white via-[80%] to-transparent p-5">
+      <div className="fixed left-0 right-0 top-0 z-50 bg-gradient-to-b from-white from-[13%] via-white via-[80%] to-transparent p-5">
         <div className="flex items-center justify-between">
           {/* Logo */}
           <div className="relative h-12 w-36">
@@ -73,7 +78,7 @@ export function MobileNav({
               className="object-contain object-left"
             />
           </div>
-          
+
           <div className="flex items-center gap-2">
             <ViewToggle />
 
@@ -102,17 +107,17 @@ export function MobileNav({
           view === "case-study" && "hidden",
         )}
       >
-        <div className="flex flex-wrap items-center justify-center gap-2.5 w-full">
-          <div className="flex items-center gap-2.5 justify-center">
+        <div className="flex w-full flex-wrap items-center justify-center gap-2.5">
+          <div className="flex items-center justify-center gap-2.5">
             {/* Type Dropdown */}
             <button
               onClick={() => setTypeOpen(true)}
-                                className={cn(
-                    "flex items-center gap-2 rounded-full px-4 py-2 text-base font-normal transition-colors focus:outline-none",
-                    typeOpen
-                      ? "bg-neutral-300 text-neutral-900"
-                      : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300"
-                  )}
+              className={cn(
+                "flex items-center gap-2 rounded-full px-4 py-2 text-base font-normal transition-colors focus:outline-none",
+                typeOpen
+                  ? "bg-neutral-300 text-neutral-900"
+                  : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
+              )}
             >
               {selectedTypeLabel}
               <motion.div
@@ -126,12 +131,12 @@ export function MobileNav({
             {/* Tag Dropdown (multi-select) */}
             <button
               onClick={() => setTagOpen(true)}
-                                className={cn(
-                    "flex items-center gap-2 rounded-full px-4 py-2 text-base font-normal transition-colors focus:outline-none whitespace-nowrap max-w-[160px] overflow-hidden text-ellipsis",
-                    tagOpen
-                      ? "bg-neutral-300 text-neutral-900"
-                      : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300"
-                  )}
+              className={cn(
+                "flex max-w-[160px] items-center gap-2 overflow-hidden text-ellipsis whitespace-nowrap rounded-full px-4 py-2 text-base font-normal transition-colors focus:outline-none",
+                tagOpen
+                  ? "bg-neutral-300 text-neutral-900"
+                  : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
+              )}
             >
               <span className="truncate">{selectedTagsLabel}</span>
               <motion.div
@@ -147,7 +152,7 @@ export function MobileNav({
             {hasAnySelection && (
               <button
                 onClick={() => setParams({ ...params, type: null, tags: [] })}
-                className="flex h-9 w-9 items-center justify-center rounded-full bg-neutral-200 text-neutral-900 transition-all hover:bg-neutral-300 p-2"
+                className="flex h-9 w-9 items-center justify-center rounded-full bg-neutral-200 p-2 text-neutral-900 transition-all hover:bg-neutral-300"
                 aria-label="Reset filters"
               >
                 <motion.span
@@ -184,7 +189,10 @@ export function MobileNav({
         onOptionSelect={(tag) => {
           const isSelected = selectedTags?.includes(tag);
           if (isSelected) {
-            void setParams({ ...params, tags: selectedTags.filter((t) => t !== tag) });
+            void setParams({
+              ...params,
+              tags: selectedTags.filter((t) => t !== tag),
+            });
           } else {
             void setParams({ ...params, tags: [...(selectedTags || []), tag] });
           }
@@ -208,12 +216,12 @@ export function MobileNav({
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.3, ease: "easeInOut" }}
-              className="relative w-full max-w-sm h-screen flex flex-col justify-end pt-3 px-2 pb-safe"
+              className="pb-safe relative flex h-screen w-full max-w-sm flex-col justify-end px-2 pt-3"
               onClick={(e) => e.stopPropagation()}
             >
-              <div className="flex flex-col gap-2 h-full">
+              <div className="flex h-full flex-col gap-2">
                 {/* Content Container */}
-                <div className="flex flex-col gap-5 flex-1 items-center justify-center">
+                <div className="flex flex-1 flex-col items-center justify-center gap-5">
                   {/* Logo */}
                   <div className="relative h-20 w-48">
                     <Image
@@ -226,7 +234,7 @@ export function MobileNav({
                   </div>
 
                   {/* Info text */}
-                  <div className="flex flex-col items-center gap-0.5 text-base text-neutral-900 text-center">
+                  <div className="flex flex-col items-center gap-0.5 text-center text-base text-neutral-900">
                     <p>
                       Made by{" "}
                       <Link
@@ -256,7 +264,7 @@ export function MobileNav({
                 {/* Dismiss Button */}
                 <motion.button
                   onClick={() => setInfoOpen(false)}
-                  className="flex h-20 w-full items-center justify-center rounded-full text-neutral-900 transition-colors hover:bg-neutral-200 shrink-0"
+                  className="flex h-20 w-full shrink-0 items-center justify-center rounded-full text-neutral-900 transition-colors hover:bg-neutral-200"
                   whileTap={{ scale: 0.98 }}
                 >
                   <motion.div
@@ -273,10 +281,10 @@ export function MobileNav({
       </AnimatePresence>
 
       {/* Submission Form */}
-      <SubmissionForm 
-        open={submissionFormOpen} 
-        onOpenChange={setSubmissionFormOpen} 
+      <SubmissionForm
+        open={submissionFormOpen}
+        onOpenChange={setSubmissionFormOpen}
       />
     </>
   );
-} 
+}

--- a/src/components/nav/view-toggle.tsx
+++ b/src/components/nav/view-toggle.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useViewParams, type View } from "@/hooks/params-parsers/use-view-params";
+
+const OPTIONS: { value: View; label: string }[] = [
+  { value: "designer", label: "Designers" },
+  { value: "case-study", label: "Case Studies" },
+];
+
+export function ViewToggle({ className }: { className?: string }) {
+  const [{ view }, setViewParams] = useViewParams();
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Browse mode"
+      className={cn(
+        "inline-flex items-center gap-0.5 rounded-full bg-neutral-200/70 p-0.5",
+        className,
+      )}
+    >
+      {OPTIONS.map((option) => {
+        const isActive = view === option.value;
+
+        return (
+          <button
+            key={option.value}
+            role="tab"
+            type="button"
+            aria-selected={isActive}
+            onClick={() => setViewParams({ view: option.value })}
+            className={cn(
+              "whitespace-nowrap rounded-full px-3 py-1 text-xs transition-colors duration-200",
+              isActive
+                ? "bg-foreground text-background"
+                : "text-neutral-600 hover:text-neutral-900",
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/nav/view-toggle.tsx
+++ b/src/components/nav/view-toggle.tsx
@@ -8,7 +8,7 @@ import {
 
 const OPTIONS: { value: View; label: string }[] = [
   { value: "designer", label: "Designers" },
-  { value: "case-study", label: "Case Studies" },
+  { value: "case-study", label: "Projects" },
 ];
 
 export function ViewToggle({ className }: { className?: string }) {

--- a/src/components/nav/view-toggle.tsx
+++ b/src/components/nav/view-toggle.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { useViewParams, type View } from "@/hooks/params-parsers/use-view-params";
+import {
+  useViewParams,
+  type View,
+} from "@/hooks/params-parsers/use-view-params";
 
 const OPTIONS: { value: View; label: string }[] = [
   { value: "designer", label: "Designers" },
@@ -16,7 +19,8 @@ export function ViewToggle({ className }: { className?: string }) {
       role="tablist"
       aria-label="Browse mode"
       className={cn(
-        "inline-flex items-center gap-0.5 rounded-full bg-neutral-200/70 p-0.5",
+        // h-9 matches the filter pills (py-2 + text-sm) so the row lines up.
+        "inline-flex h-9 flex-shrink-0 items-center gap-0.5 rounded-full bg-neutral-200/70 p-0.5",
         className,
       )}
     >
@@ -31,7 +35,7 @@ export function ViewToggle({ className }: { className?: string }) {
             aria-selected={isActive}
             onClick={() => setViewParams({ view: option.value })}
             className={cn(
-              "whitespace-nowrap rounded-full px-3 py-1 text-xs transition-colors duration-200",
+              "flex h-8 items-center whitespace-nowrap rounded-full px-3.5 text-sm transition-colors duration-200",
               isActive
                 ? "bg-foreground text-background"
                 : "text-neutral-600 hover:text-neutral-900",

--- a/src/components/nav/view-toggle.tsx
+++ b/src/components/nav/view-toggle.tsx
@@ -35,7 +35,7 @@ export function ViewToggle({ className }: { className?: string }) {
             aria-selected={isActive}
             onClick={() => setViewParams({ view: option.value })}
             className={cn(
-              "flex h-8 items-center whitespace-nowrap rounded-full px-3.5 text-sm transition-colors duration-200",
+              "flex h-8 items-center whitespace-nowrap rounded-full px-3 text-sm transition-colors duration-200",
               isActive
                 ? "bg-foreground text-background"
                 : "text-neutral-600 hover:text-neutral-900",

--- a/src/env.js
+++ b/src/env.js
@@ -13,6 +13,9 @@ export const env = createEnv({
       .default("development"),
     NOTION_DATABASE_ID: z.string(),
     NOTION_API_KEY: z.string(),
+    NOTION_CASE_STUDY_DATABASE_ID: z.string(),
+    ANTHROPIC_API_KEY: z.string(),
+    BLOB_READ_WRITE_TOKEN: z.string(),
   },
 
   /**
@@ -31,6 +34,9 @@ export const env = createEnv({
   runtimeEnv: {
     NOTION_DATABASE_ID: process.env.NOTION_DATABASE_ID,
     NOTION_API_KEY: process.env.NOTION_API_KEY,
+    NOTION_CASE_STUDY_DATABASE_ID: process.env.NOTION_CASE_STUDY_DATABASE_ID,
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    BLOB_READ_WRITE_TOKEN: process.env.BLOB_READ_WRITE_TOKEN,
     DATABASE_URL: process.env.DATABASE_URL,
     NODE_ENV: process.env.NODE_ENV,
     // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,

--- a/src/env.js
+++ b/src/env.js
@@ -13,9 +13,13 @@ export const env = createEnv({
       .default("development"),
     NOTION_DATABASE_ID: z.string(),
     NOTION_API_KEY: z.string(),
-    NOTION_CASE_STUDY_DATABASE_ID: z.string(),
-    ANTHROPIC_API_KEY: z.string(),
-    BLOB_READ_WRITE_TOKEN: z.string(),
+
+    // Case study support is optional: the site builds and serves the designer
+    // view without any of these. Missing credentials disable the case study
+    // sync rather than failing the build.
+    NOTION_CASE_STUDY_DATABASE_ID: z.string().optional(),
+    ANTHROPIC_API_KEY: z.string().optional(),
+    BLOB_READ_WRITE_TOKEN: z.string().optional(),
   },
 
   /**

--- a/src/hooks/params-parsers/use-case-study-filter-params.ts
+++ b/src/hooks/params-parsers/use-case-study-filter-params.ts
@@ -1,0 +1,30 @@
+import { parseAsArrayOf, parseAsString, useQueryStates } from "nuqs";
+
+const CASE_STUDY_FILTER_PARAMS = {
+  types: parseAsArrayOf(parseAsString).withDefault([]).withOptions({
+    clearOnDefault: true,
+    shallow: false,
+  }),
+  industries: parseAsArrayOf(parseAsString).withDefault([]).withOptions({
+    clearOnDefault: true,
+    shallow: false,
+  }),
+};
+
+export function hasAnyCaseStudyFilterApplied(
+  filterParams: ReturnType<typeof useCaseStudyFilterParams>[0],
+) {
+  return filterParams.types.length > 0 || filterParams.industries.length > 0;
+}
+
+export const CASE_STUDY_URL_KEYS = {
+  types: "types",
+  industries: "industries",
+};
+
+export function useCaseStudyFilterParams() {
+  return useQueryStates(CASE_STUDY_FILTER_PARAMS, {
+    urlKeys: CASE_STUDY_URL_KEYS,
+    shallow: false,
+  });
+}

--- a/src/hooks/params-parsers/use-view-params.ts
+++ b/src/hooks/params-parsers/use-view-params.ts
@@ -1,0 +1,19 @@
+import { parseAsStringEnum, useQueryStates } from "nuqs";
+
+export const VIEWS = ["designer", "case-study"] as const;
+export type View = (typeof VIEWS)[number];
+
+const VIEW_PARAMS = {
+  view: parseAsStringEnum([...VIEWS])
+    .withDefault("designer")
+    .withOptions({
+      clearOnDefault: true,
+      // Not shallow: switching views re-runs the server prefetch, matching how
+      // the existing filters behave.
+      shallow: false,
+    }),
+};
+
+export function useViewParams() {
+  return useQueryStates(VIEW_PARAMS, { shallow: false });
+}

--- a/src/lib/ai-summary.ts
+++ b/src/lib/ai-summary.ts
@@ -1,8 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import * as cheerio from "cheerio";
 
-const anthropic = new Anthropic();
-
 // Short summaries only — this is a card caption, not an article.
 const MAX_TOKENS = 300;
 const MAX_SOURCE_CHARS = 12_000;
@@ -52,6 +50,11 @@ export async function generateSummary({
   types,
   industries,
 }: SummaryInput): Promise<string | null> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.warn("ANTHROPIC_API_KEY not set — skipping summary for", name);
+    return null;
+  }
+
   const source = sourceText ?? (url ? await fetchPageText(url) : null);
 
   if (!source) {
@@ -69,6 +72,8 @@ export async function generateSummary({
     .join("\n");
 
   try {
+    const anthropic = new Anthropic();
+
     const message = await anthropic.messages.create({
       model: "claude-haiku-4-5",
       max_tokens: MAX_TOKENS,

--- a/src/lib/ai-summary.ts
+++ b/src/lib/ai-summary.ts
@@ -1,0 +1,100 @@
+import Anthropic from "@anthropic-ai/sdk";
+import * as cheerio from "cheerio";
+
+const anthropic = new Anthropic();
+
+// Short summaries only — this is a card caption, not an article.
+const MAX_TOKENS = 300;
+const MAX_SOURCE_CHARS = 12_000;
+
+interface SummaryInput {
+  name: string;
+  url: string | null;
+  sourceText: string | null;
+  types: string[];
+  industries: string[];
+}
+
+/**
+ * Pulls readable text off a page for summarising.
+ *
+ * Mirrors the fetch/cheerio approach used by the OpenGraph scraper in the
+ * designer sync route. Not usable for x.com, which renders client-side and
+ * blocks data-centre traffic — those entries rely on `sourceText` instead.
+ */
+async function fetchPageText(url: string): Promise<string | null> {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) return null;
+
+    const $ = cheerio.load(await response.text());
+    $("script, style, noscript, svg").remove();
+
+    const text = $("body").text().replace(/\s+/g, " ").trim();
+    return text === "" ? null : text.slice(0, MAX_SOURCE_CHARS);
+  } catch (error) {
+    console.error("Error fetching page text for", url, error);
+    return null;
+  }
+}
+
+/**
+ * Writes a one or two sentence summary of a case study.
+ *
+ * Prefers the captured source text (e.g. the tweet body) and falls back to
+ * scraping the linked page. Tags are never generated here — those stay manual
+ * in Notion.
+ */
+export async function generateSummary({
+  name,
+  url,
+  sourceText,
+  types,
+  industries,
+}: SummaryInput): Promise<string | null> {
+  const source = sourceText ?? (url ? await fetchPageText(url) : null);
+
+  if (!source) {
+    console.warn("No source material to summarise for", name);
+    return null;
+  }
+
+  const context = [
+    `Project name: ${name}`,
+    url ? `URL: ${url}` : null,
+    types.length > 0 ? `Type: ${types.join(", ")}` : null,
+    industries.length > 0 ? `Industry: ${industries.join(", ")}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  try {
+    const message = await anthropic.messages.create({
+      model: "claude-haiku-4-5",
+      max_tokens: MAX_TOKENS,
+      system:
+        "You write short blurbs for a curated gallery of design work. " +
+        "Given source material about a project, reply with one or two " +
+        "sentences describing what it is and what makes the design notable. " +
+        "Write plainly and concretely. Do not use marketing language, do not " +
+        "start with the project name, and reply with the summary only.",
+      messages: [
+        {
+          role: "user",
+          content: `${context}\n\nSource material:\n${source}`,
+        },
+      ],
+    });
+
+    const summary = message.content
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("")
+      .trim();
+
+    return summary === "" ? null : summary;
+  } catch (error) {
+    console.error("Error generating summary for", name, error);
+    return null;
+  }
+}

--- a/src/lib/blob-storage.ts
+++ b/src/lib/blob-storage.ts
@@ -1,0 +1,62 @@
+import { put } from "@vercel/blob";
+
+const BLOB_HOST_SUFFIX = ".public.blob.vercel-storage.com";
+
+export function isBlobUrl(url: string): boolean {
+  try {
+    return new URL(url).hostname.endsWith(BLOB_HOST_SUFFIX);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Copies a remote asset into Vercel Blob and returns the stable public URL.
+ *
+ * Notion file URLs expire after roughly an hour and twimg links rot, so
+ * anything we intend to keep rendering has to be mirrored rather than linked.
+ * URLs that already point at Blob are returned untouched.
+ */
+export async function mirrorToBlob(
+  sourceUrl: string,
+  key: string,
+): Promise<string | null> {
+  if (isBlobUrl(sourceUrl)) return sourceUrl;
+
+  try {
+    const response = await fetch(sourceUrl);
+    if (!response.ok) {
+      console.error(
+        `Failed to download ${sourceUrl} for mirroring:`,
+        response.status,
+      );
+      return null;
+    }
+
+    const blob = await put(key, response.body!, {
+      access: "public",
+      contentType: response.headers.get("content-type") ?? undefined,
+      addRandomSuffix: true,
+    });
+
+    return blob.url;
+  } catch (error) {
+    console.error("Error mirroring to blob:", sourceUrl, error);
+    return null;
+  }
+}
+
+/** Mirrors a file already on disk — used by the local ingest script. */
+export async function uploadFileToBlob(
+  data: Buffer,
+  key: string,
+  contentType: string,
+): Promise<string> {
+  const blob = await put(key, data, {
+    access: "public",
+    contentType,
+    addRandomSuffix: true,
+  });
+
+  return blob.url;
+}

--- a/src/lib/blob-storage.ts
+++ b/src/lib/blob-storage.ts
@@ -23,6 +23,11 @@ export async function mirrorToBlob(
 ): Promise<string | null> {
   if (isBlobUrl(sourceUrl)) return sourceUrl;
 
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    console.warn("BLOB_READ_WRITE_TOKEN not set — skipping mirror of", sourceUrl);
+    return null;
+  }
+
   try {
     const response = await fetch(sourceUrl);
     if (!response.ok) {
@@ -52,6 +57,13 @@ export async function uploadFileToBlob(
   key: string,
   contentType: string,
 ): Promise<string> {
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    throw new Error(
+      "BLOB_READ_WRITE_TOKEN is not set. Create a Vercel Blob store, then copy " +
+        "the token into your local .env before running this script.",
+    );
+  }
+
   const blob = await put(key, data, {
     access: "public",
     contentType,

--- a/src/lib/case-study-sync.ts
+++ b/src/lib/case-study-sync.ts
@@ -1,0 +1,94 @@
+import type {
+  PageObjectResponse,
+  RichTextItemResponse,
+} from "@notionhq/client/build/src/api-endpoints";
+import { notion } from "./notion-sync";
+
+export interface NotionCaseStudy {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  websiteUrl: string | null;
+  types: string[];
+  industries: string[];
+  infoRole: string | null;
+  infoTeam: string | null;
+  videoUrl: string | null;
+  posterUrl: string | null;
+  sourceText: string | null;
+}
+
+type Properties = PageObjectResponse["properties"];
+
+function plainText(properties: Properties, key: string): string | null {
+  const property = properties[key];
+  if (property?.type !== "rich_text") return null;
+
+  const text = property.rich_text
+    .map((chunk: RichTextItemResponse) => chunk.plain_text)
+    .join("")
+    .trim();
+
+  return text === "" ? null : text;
+}
+
+function multiSelect(properties: Properties, key: string): string[] {
+  const property = properties[key];
+  if (property?.type !== "multi_select") return [];
+  return property.multi_select.map((option) => option.name);
+}
+
+function url(properties: Properties, key: string): string | null {
+  const property = properties[key];
+  if (property?.type !== "url") return null;
+  const value = property.url?.trim();
+  return value === "" ? null : (value ?? null);
+}
+
+/**
+ * Reads the "design / case studies" Notion database.
+ *
+ * Property names here are capitalised and differ from the designer database's
+ * lowercase keys, so this deliberately does not share a mapper with
+ * `fetchNotionData`. Sub-items are skipped so only top-level rows become cards.
+ */
+export async function fetchCaseStudyData(): Promise<NotionCaseStudy[]> {
+  try {
+    const response = await notion.databases.query({
+      database_id: process.env.NOTION_CASE_STUDY_DATABASE_ID!,
+    });
+
+    return response.results
+      .filter((page): page is PageObjectResponse => "properties" in page)
+      .filter((page) => {
+        const parent = page.properties["Parent item"];
+        return parent?.type !== "relation" || parent.relation.length === 0;
+      })
+      .map((page) => {
+        const properties = page.properties;
+
+        return {
+          id: page.id,
+          createdAt: page.created_time,
+          updatedAt: page.last_edited_time,
+          name:
+            properties.Name?.type === "title"
+              ? (properties.Name.title[0]?.plain_text ?? "")
+              : "",
+          websiteUrl: url(properties, "URL"),
+          types: multiSelect(properties, "Type"),
+          industries: multiSelect(properties, "Industries"),
+          infoRole: plainText(properties, "Info / Role"),
+          infoTeam: plainText(properties, "Info / Team"),
+          videoUrl: url(properties, "Video"),
+          posterUrl: url(properties, "Poster"),
+          sourceText: plainText(properties, "Source Text"),
+        };
+      })
+      .filter((item) => item.name !== "");
+  } catch (error) {
+    console.error("Error fetching Notion case study data:", error);
+    throw error;
+  }
+}

--- a/src/lib/screenshot.ts
+++ b/src/lib/screenshot.ts
@@ -1,0 +1,42 @@
+interface MicrolinkResponse {
+  status: string;
+  data?: {
+    screenshot?: {
+      url?: string;
+    };
+  };
+}
+
+/**
+ * Captures a screenshot of a page and returns a hosted image URL.
+ *
+ * Kept behind one helper so the provider stays swappable. Only meaningful for
+ * ordinary websites — x.com and friends block automated capture, so video
+ * entries use their poster frame instead of calling this.
+ */
+export async function fetchScreenshotUrl(url: string): Promise<string | null> {
+  const endpoint = new URL("https://api.microlink.io");
+  endpoint.searchParams.set("url", url);
+  endpoint.searchParams.set("screenshot", "true");
+  endpoint.searchParams.set("meta", "false");
+  endpoint.searchParams.set("waitUntil", "networkidle2");
+
+  const apiKey = process.env.SCREENSHOT_API_KEY;
+
+  try {
+    const response = await fetch(endpoint, {
+      headers: apiKey ? { "x-api-key": apiKey } : undefined,
+    });
+
+    if (!response.ok) {
+      console.error("Screenshot request failed for", url, response.status);
+      return null;
+    }
+
+    const body = (await response.json()) as MicrolinkResponse;
+    return body.data?.screenshot?.url ?? null;
+  } catch (error) {
+    console.error("Error fetching screenshot for", url, error);
+    return null;
+  }
+}

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,3 +1,4 @@
+import { caseStudyRouter } from "@/server/api/routers/case-study";
 import { collectableRouter } from "@/server/api/routers/collectable";
 import { createCallerFactory, createTRPCRouter } from "@/server/api/trpc";
 
@@ -8,6 +9,7 @@ import { createCallerFactory, createTRPCRouter } from "@/server/api/trpc";
  */
 export const appRouter = createTRPCRouter({
   collectable: collectableRouter,
+  caseStudy: caseStudyRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/case-study.ts
+++ b/src/server/api/routers/case-study.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+import { createTRPCRouter, publicProcedure } from "@/server/api/trpc";
+import { caseStudies } from "@/server/db/schema";
+import { and, arrayOverlaps, desc, eq, sql } from "drizzle-orm";
+
+const CASE_STUDY_PER_PAGE = 12;
+
+const FILTER_QUERY_OBJECT = z.object({
+  types: z.array(z.string()).optional(),
+  industries: z.array(z.string()).optional(),
+});
+
+const FILTER_QUERY_OBJECT_WITH_PAGINATION = FILTER_QUERY_OBJECT.extend({
+  cursor: z.number().default(0),
+  limit: z.number().default(CASE_STUDY_PER_PAGE),
+});
+
+export const caseStudyRouter = createTRPCRouter({
+  getInfiniteScroll: publicProcedure
+    .input(FILTER_QUERY_OBJECT_WITH_PAGINATION)
+    .query(async ({ ctx, input }) => {
+      const { types, industries, cursor, limit } = input;
+
+      const items = await ctx.db
+        .selectDistinct({
+          id: caseStudies.id,
+          name: caseStudies.name,
+          websiteUrl: caseStudies.websiteUrl,
+          mediaType: caseStudies.mediaType,
+          videoUrl: caseStudies.videoUrl,
+          posterUrl: caseStudies.posterUrl,
+          coverImageUrl: caseStudies.coverImageUrl,
+          types: caseStudies.types,
+          industries: caseStudies.industries,
+          infoRole: caseStudies.infoRole,
+          infoTeam: caseStudies.infoTeam,
+          aiSummary: caseStudies.aiSummary,
+          createdAt: caseStudies.createdAt,
+        })
+        .from(caseStudies)
+        .limit(limit + 1)
+        .where(
+          and(
+            eq(caseStudies.isBroken, false),
+            types && types.length > 0
+              ? arrayOverlaps(caseStudies.types, types)
+              : sql`TRUE`,
+            industries && industries.length > 0
+              ? arrayOverlaps(caseStudies.industries, industries)
+              : sql`TRUE`,
+          ),
+        )
+        .offset(cursor)
+        .orderBy(desc(caseStudies.createdAt));
+
+      return {
+        items: items.slice(0, limit),
+        nextCursor: items.length > limit ? cursor + limit : undefined,
+      };
+    }),
+
+  getUniqueTypes: publicProcedure.query(async ({ ctx }) => {
+    const rows = await ctx.db.query.caseStudies.findMany({
+      columns: { types: true },
+    });
+
+    return [...new Set(rows.flatMap((row) => row.types ?? []))].filter(
+      (type) => type !== "",
+    );
+  }),
+
+  getUniqueIndustries: publicProcedure.query(async ({ ctx }) => {
+    const rows = await ctx.db.query.caseStudies.findMany({
+      columns: { industries: true },
+    });
+
+    return [...new Set(rows.flatMap((row) => row.industries ?? []))].filter(
+      (industry) => industry !== "",
+    );
+  }),
+});

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -40,6 +40,47 @@ export const collectables = createTable(
   }),
 );
 
+export const caseStudies = createTable(
+  "case_study",
+  {
+    id: varchar("id", { length: 36 }).primaryKey(),
+    createdAt: timestamp("created_at", { withTimezone: true }),
+    updatedAt: timestamp("updated_at", { withTimezone: true }),
+    name: varchar("name", { length: 256 }).notNull(),
+    websiteUrl: text("website_url"),
+
+    // "video" when a demo video is available, otherwise "website".
+    mediaType: text("media_type").notNull().default("website"),
+    videoUrl: text("video_url"),
+    posterUrl: text("poster_url"),
+
+    // Screenshot cover, only fetched for website-type entries.
+    coverImageUrl: text("cover_image_url"),
+    coverImageLastFetchedAt: timestamp("cover_image_last_fetched_at", {
+      withTimezone: true,
+    }),
+
+    // Notion "Type" is a multi-select here, unlike the designer database.
+    types: text("types").array(),
+    industries: text("industries").array(),
+    infoRole: text("info_role"),
+    infoTeam: text("info_team"),
+
+    // Raw source copy (e.g. tweet text) used as AI summary input when the
+    // linked page cannot be scraped.
+    sourceText: text("source_text"),
+    aiSummary: text("ai_summary"),
+    aiSummaryGeneratedAt: timestamp("ai_summary_generated_at", {
+      withTimezone: true,
+    }),
+
+    isBroken: boolean("is_broken").notNull().default(false),
+  },
+  (caseStudy) => ({
+    nameIndex: index("case_study_name_idx").on(caseStudy.name),
+  }),
+);
+
 export const submissions = createTable(
   "submission",
   {

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/notion-sync",
       "schedule": "25 19 * * *"
+    },
+    {
+      "path": "/api/case-study-sync",
+      "schedule": "35 19 * * *"
     }
   ]
 }


### PR DESCRIPTION
Adds a second browsing mode alongside the designer grid, backed by the
"design / case studies" Notion database and reachable from a toggle in the
nav (?view=case-study).

Pipeline mirrors the existing one — Notion -> Neon -> tRPC -> client — but
uses a separate cur8d_case_study table and router, since case studies carry
different fields (multi-select Type, Industries, role/team, summary, media).

Cards are video-first: a demo plays muted on hover (desktop) or when scrolled
into view (touch), falling back to a poster frame and honouring
prefers-reduced-motion. Website entries fall back to a screenshot, then to the
existing placeholder.

Media sourcing is split deliberately. X blocks data-centre IPs, so the cron
never talks to it: scripts/ingest-video.ts runs locally, resolves the video
with yt-dlp, uploads it to Vercel Blob, and writes the URLs back into Notion.
The sync route then only ever reads Notion and Blob. Summaries are generated
during sync and prefer captured post text over scraping, since x.com cannot be
scraped server-side either.

Setup required: share the case study database with the existing Notion
integration, add Video / Poster / Source Text URL properties to it, set
NOTION_CASE_STUDY_DATABASE_ID, ANTHROPIC_API_KEY and BLOB_READ_WRITE_TOKEN,
then run db:push.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NNnSDzJBTwzoh6Lhj1vv1t