### PR TITLE
Add sorting functionality to collectable filters

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { api, HydrateClient } from "@/trpc/server";
 import { DesktopNav } from "@/components/nav/desktop-nav";
 import { MobileNav } from "@/components/nav/mobile-nav";
 import CollectableGrid from "@/components/collectable-grid";
+import { DEFAULT_SORT } from "@/lib/sort-options";
 
 const COLLECTABLE_PER_PAGE = 12;
 
@@ -12,6 +13,7 @@ export default async function Home() {
   const initialInfiniteScrollData = await api.collectable.getInfiniteScroll({
     type: undefined,
     tags: [],
+    sort: DEFAULT_SORT,
     limit: COLLECTABLE_PER_PAGE,
   });
 

--- a/src/components/collectable-grid.tsx
+++ b/src/components/collectable-grid.tsx
@@ -30,6 +30,7 @@ function CollectableGrid({ initialData, pageSize }: CollectableGridProps) {
         limit: pageSize,
         type: filterParams.type,
         tags: filterParams.tags,
+        sort: filterParams.sort,
       },
       {
         getNextPageParam: (lastPage) => lastPage.nextCursor,

--- a/src/components/nav/horizontal-filter.tsx
+++ b/src/components/nav/horizontal-filter.tsx
@@ -7,6 +7,11 @@ import { useMemo, useState } from "react";
 import { DropdownMenu } from "@/components/ui/dropdown-menu";
 import { CaretDown } from "@phosphor-icons/react";
 import { motion } from "motion/react";
+import {
+  DEFAULT_SORT,
+  SORT_OPTIONS,
+  getSortLabel,
+} from "@/lib/sort-options";
 
 interface HorizontalFilterProps {
   tagOptions: string[];
@@ -18,11 +23,15 @@ export function HorizontalFilter({
   typeOptions,
 }: HorizontalFilterProps) {
   const [params, setParams] = useCollectableFilterParams();
-  const { type: selectedType, tags: selectedTags } = params;
+  const { type: selectedType, tags: selectedTags, sort: selectedSort } = params;
 
   const hasAnySelection = useMemo(() => {
-    return selectedType || (selectedTags && selectedTags.length > 0);
-  }, [selectedType, selectedTags]);
+    return (
+      selectedType ||
+      (selectedTags && selectedTags.length > 0) ||
+      selectedSort !== DEFAULT_SORT
+    );
+  }, [selectedType, selectedTags, selectedSort]);
 
   // Helper for showing selected tags as comma-separated
   function toTitleCase(str: string) {
@@ -45,6 +54,7 @@ export function HorizontalFilter({
   // Add state to track open status for each dropdown
   const [typeOpen, setTypeOpen] = useState(false);
   const [tagOpen, setTagOpen] = useState(false);
+  const [sortOpen, setSortOpen] = useState(false);
 
   return (
     <div className="flex items-center gap-2 pb-0 pt-0">
@@ -126,9 +136,44 @@ export function HorizontalFilter({
         </DropdownMenu.Content>
       </DropdownMenu.Root>
 
+      {/* Sort Dropdown */}
+      <DropdownMenu.Root open={sortOpen} onOpenChange={setSortOpen}>
+        <DropdownMenu.Trigger asChild>
+          <button
+            className={cn(
+              "flex items-center gap-2 rounded-full px-4 py-2 text-sm font-normal transition-colors focus:outline-none",
+              sortOpen
+                ? "bg-black text-white"
+                : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300"
+            )}
+          >
+            {getSortLabel(selectedSort)}
+            <motion.div
+              animate={{ rotate: sortOpen ? 360 : 270 }}
+              transition={{ duration: 0.2, ease: "easeInOut" }}
+            >
+              <CaretDown weight="fill" className="h-4 w-4" />
+            </motion.div>
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content open={sortOpen}>
+          {SORT_OPTIONS.map((option) => (
+            <DropdownMenu.Item
+              key={option.value}
+              onSelect={() => void setParams({ ...params, sort: option.value })}
+              selected={selectedSort === option.value}
+            >
+              {option.label}
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+
       {/* Reset button (moved to right of expertise dropdown) */}
       <button
-        onClick={() => setParams({ ...params, type: null, tags: [] })}
+        onClick={() =>
+          setParams({ ...params, type: null, tags: [], sort: DEFAULT_SORT })
+        }
         className={cn(
           "flex h-9 w-9 items-center justify-center rounded-full bg-neutral-200 text-neutral-900 transition-all hover:bg-neutral-300",
           !hasAnySelection && "pointer-events-none opacity-0"

--- a/src/components/nav/mobile-nav.tsx
+++ b/src/components/nav/mobile-nav.tsx
@@ -9,6 +9,12 @@ import { motion, AnimatePresence } from "motion/react";
 import Image from "next/image";
 import Link from "next/link";
 import { SubmissionForm } from "@/components/submission-form";
+import {
+  DEFAULT_SORT,
+  SORT_OPTIONS,
+  getSortLabel,
+  getSortValueFromLabel,
+} from "@/lib/sort-options";
 
 interface MobileNavProps {
   tagOptions: string[];
@@ -17,12 +23,16 @@ interface MobileNavProps {
 
 export function MobileNav({ tagOptions, typeOptions }: MobileNavProps) {
   const [params, setParams] = useCollectableFilterParams();
-  const { type: selectedType, tags: selectedTags } = params;
+  const { type: selectedType, tags: selectedTags, sort: selectedSort } = params;
   const [submissionFormOpen, setSubmissionFormOpen] = useState(false);
 
   const hasAnySelection = useMemo(() => {
-    return selectedType || (selectedTags && selectedTags.length > 0);
-  }, [selectedType, selectedTags]);
+    return (
+      selectedType ||
+      (selectedTags && selectedTags.length > 0) ||
+      selectedSort !== DEFAULT_SORT
+    );
+  }, [selectedType, selectedTags, selectedSort]);
 
   // Helper for showing selected tags as comma-separated
   function toTitleCase(str: string) {
@@ -45,6 +55,7 @@ export function MobileNav({ tagOptions, typeOptions }: MobileNavProps) {
   // Add state to track open status for each dropdown
   const [typeOpen, setTypeOpen] = useState(false);
   const [tagOpen, setTagOpen] = useState(false);
+  const [sortOpen, setSortOpen] = useState(false);
   const [infoOpen, setInfoOpen] = useState(false);
 
   return (
@@ -116,10 +127,37 @@ export function MobileNav({ tagOptions, typeOptions }: MobileNavProps) {
               </motion.div>
             </button>
 
+            {/* Sort Dropdown */}
+            <button
+              onClick={() => setSortOpen(true)}
+              className={cn(
+                "flex items-center gap-2 rounded-full px-4 py-2 text-base font-normal transition-colors focus:outline-none whitespace-nowrap max-w-[160px] overflow-hidden text-ellipsis",
+                sortOpen
+                  ? "bg-neutral-300 text-neutral-900"
+                  : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300"
+              )}
+            >
+              <span className="truncate">{getSortLabel(selectedSort)}</span>
+              <motion.div
+                animate={{ rotate: sortOpen ? 180 : 0 }}
+                transition={{ duration: 0.2, ease: "easeInOut" }}
+                className="flex-shrink-0"
+              >
+                <CaretDown weight="fill" className="h-5 w-5" />
+              </motion.div>
+            </button>
+
             {/* Reset button */}
             {hasAnySelection && (
               <button
-                onClick={() => setParams({ ...params, type: null, tags: [] })}
+                onClick={() =>
+                  setParams({
+                    ...params,
+                    type: null,
+                    tags: [],
+                    sort: DEFAULT_SORT,
+                  })
+                }
                 className="flex h-9 w-9 items-center justify-center rounded-full bg-neutral-200 text-neutral-900 transition-all hover:bg-neutral-300 p-2"
                 aria-label="Reset filters"
               >
@@ -163,6 +201,20 @@ export function MobileNav({ tagOptions, typeOptions }: MobileNavProps) {
           }
         }}
         multiSelect={true}
+      />
+
+      <MobileDropdown
+        open={sortOpen}
+        onOpenChange={setSortOpen}
+        options={SORT_OPTIONS.map((option) => option.label)}
+        selectedOptions={[getSortLabel(selectedSort)]}
+        onOptionSelect={(label) => {
+          const sort = getSortValueFromLabel(label);
+          if (sort) {
+            void setParams({ ...params, sort });
+          }
+        }}
+        multiSelect={false}
       />
 
       {/* Info Overlay */}

--- a/src/hooks/params-parsers/use-collectable-filter-params.ts
+++ b/src/hooks/params-parsers/use-collectable-filter-params.ts
@@ -1,4 +1,10 @@
-import { parseAsString, parseAsArrayOf, useQueryStates } from "nuqs";
+import {
+  parseAsString,
+  parseAsArrayOf,
+  parseAsStringLiteral,
+  useQueryStates,
+} from "nuqs";
+import { DEFAULT_SORT, SORT_VALUES } from "@/lib/sort-options";
 
 const COLLECTABLE_FILTER_PARAMS = {
   type: parseAsString.withDefault("").withOptions({
@@ -9,17 +15,28 @@ const COLLECTABLE_FILTER_PARAMS = {
     clearOnDefault: true,
     shallow: false,
   }),
+  sort: parseAsStringLiteral(SORT_VALUES)
+    .withDefault(DEFAULT_SORT)
+    .withOptions({
+      clearOnDefault: true,
+      shallow: false,
+    }),
 };
 
 export function hasAnyFilterApplied(
   filterParams: ReturnType<typeof useCollectableFilterParams>[0],
 ) {
-  return filterParams.type !== "" || filterParams.tags.length > 0;
+  return (
+    filterParams.type !== "" ||
+    filterParams.tags.length > 0 ||
+    filterParams.sort !== DEFAULT_SORT
+  );
 }
 
 export const URL_KEYS = {
   type: "type",
   tags: "tags",
+  sort: "sort",
 };
 
 export function useCollectableFilterParams() {

--- a/src/lib/sort-options.ts
+++ b/src/lib/sort-options.ts
@@ -1,0 +1,25 @@
+export const SORT_VALUES = [
+  "recent",
+  "earliest",
+  "name-asc",
+  "name-desc",
+] as const;
+
+export type SortValue = (typeof SORT_VALUES)[number];
+
+export const DEFAULT_SORT: SortValue = "name-asc";
+
+export const SORT_OPTIONS: { value: SortValue; label: string }[] = [
+  { value: "recent", label: "Recently Added" },
+  { value: "earliest", label: "Earliest Added" },
+  { value: "name-asc", label: "Name A–Z" },
+  { value: "name-desc", label: "Name Z–A" },
+];
+
+export function getSortLabel(sort: SortValue) {
+  return SORT_OPTIONS.find((option) => option.value === sort)?.label ?? "Sort";
+}
+
+export function getSortValueFromLabel(label: string) {
+  return SORT_OPTIONS.find((option) => option.label === label)?.value;
+}

--- a/src/server/api/routers/collectable.ts
+++ b/src/server/api/routers/collectable.ts
@@ -8,13 +8,41 @@ import {
   sql,
   arrayOverlaps,
   asc,
+  desc,
 } from "drizzle-orm";
+import { DEFAULT_SORT, SORT_VALUES, type SortValue } from "@/lib/sort-options";
 
 const COLLECTABLE_PER_PAGE = 12;
+
+/**
+ * `createdAt` is nullable, so both time-based orderings push nulls to the end
+ * rather than letting Postgres default them to the top of a DESC sort. Name is
+ * the tiebreaker so offset pagination stays deterministic.
+ */
+function getOrderBy(sort: SortValue) {
+  switch (sort) {
+    case "recent":
+      return [
+        sql`${collectables.createdAt} DESC NULLS LAST`,
+        asc(collectables.name),
+      ];
+    case "earliest":
+      return [
+        sql`${collectables.createdAt} ASC NULLS LAST`,
+        asc(collectables.name),
+      ];
+    case "name-desc":
+      return [desc(collectables.name)];
+    case "name-asc":
+    default:
+      return [asc(collectables.name)];
+  }
+}
 
 const FILTER_QUERY_OBJECT = z.object({
   type: z.string().optional(),
   tags: z.array(z.string()).optional(),
+  sort: z.enum(SORT_VALUES).default(DEFAULT_SORT),
 });
 
 const FILTER_QUERY_OBJECT_WITH_PAGINATION = FILTER_QUERY_OBJECT.extend({
@@ -34,7 +62,7 @@ export const collectableRouter = createTRPCRouter({
   getInfiniteScroll: publicProcedure
     .input(FILTER_QUERY_OBJECT_WITH_PAGINATION)
     .query(async ({ ctx, input }) => {
-      const { type, tags, cursor, limit } = input;
+      const { type, tags, cursor, limit, sort } = input;
 
       const query = ctx.db
         .selectDistinct({
@@ -58,7 +86,7 @@ export const collectableRouter = createTRPCRouter({
           ),
         )
         .offset(cursor)
-        .orderBy(asc(collectables.name));
+        .orderBy(...getOrderBy(sort));
 
       const items = await query;
       let nextCursor: number | undefined = undefined;


### PR DESCRIPTION
## Summary
This PR adds sorting capabilities to the collectable filtering system, allowing users to sort items by recently added, earliest added, or alphabetically (A–Z or Z–A).

## Key Changes
- **New sort options library** (`src/lib/sort-options.ts`): Created a centralized module defining sort values, labels, and utility functions for converting between them
- **Filter parameter updates**: Extended `useCollectableFilterParams` hook to include a `sort` parameter with URL persistence via the `nuqs` library
- **UI components**: Added sort dropdown buttons to both mobile and horizontal filter navigation components with animated caret indicators
- **Backend sorting logic**: Implemented `getOrderBy()` function in the collectable router that handles different sort strategies:
  - Time-based sorts (`recent`/`earliest`) use `NULLS LAST` to ensure consistent pagination with null `createdAt` values
  - Name-based sorts use ascending/descending order
  - Name is used as a tiebreaker for deterministic offset pagination
- **Reset button updates**: Modified reset functionality in both navigation components to also reset sort to the default value
- **Filter state tracking**: Updated `hasAnySelection` logic across components to consider sort as an active filter when it differs from the default

## Notable Implementation Details
- Sort parameter defaults to `"name-asc"` and is cleared from URL when set to default value
- The `getOrderBy()` function uses raw SQL for time-based sorts to properly handle null values with `NULLS LAST` clause
- Sort selection is single-select (unlike tags which support multi-select)
- Mobile and desktop filter UIs maintain consistent styling and animation patterns

https://claude.ai/code/session_01EGJ5j7PHSxUt7EqwN4cQsb