### PR TITLE
Add AI-generated descriptions for designer directory entries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,11 @@ DATABASE_URL="postgresql://postgres:password@localhost:5432/cur8d"
 NOTION_DATABASE_ID="87a11304-065c-41ff-bf52-64164ccd36bc"
 NOTION_API_KEY="secret_1234567890"
 
+# Optional. Writes the blurb under each card — designer descriptions during the
+# Notion sync, case study summaries during the case study sync. Without it both
+# syncs run as normal and the rows simply carry no blurb.
+ANTHROPIC_API_KEY="sk-ant-1234567890"
+
 # --- Case studies (all optional) ---------------------------------------------
 # The app builds and serves the designer view without any of these. Leave them
 # unset and the case study sync simply no-ops.
@@ -23,10 +28,6 @@ NOTION_API_KEY="secret_1234567890"
 # Notion "design / case studies" database. Must be shared with the integration
 # above, otherwise queries come back empty.
 NOTION_CASE_STUDY_DATABASE_ID="944872db-d32d-4735-b7c6-d466fe57fce2"
-
-# Used to generate case study summaries during sync. Without it, rows sync but
-# get no summary.
-ANTHROPIC_API_KEY="sk-ant-1234567890"
 
 # Hosts demo videos and their poster frames. On Vercel this is injected
 # automatically once a Blob store is connected to the project — only set it by

--- a/src/app/api/notion-sync/route.ts
+++ b/src/app/api/notion-sync/route.ts
@@ -195,7 +195,10 @@ export async function GET() {
   // Describe rows whose URL is new or has moved — the old description belongs
   // to a page this entry no longer points at — then spend what is left of the
   // per-run budget backfilling rows that have never had one.
-  const itemsToDescribe = [...urlAlteredItems, ...newItems].map((item) => ({
+  const itemsToDescribe: DescribableItem[] = [
+    ...urlAlteredItems,
+    ...newItems,
+  ].map((item) => ({
     id: item.id,
     name: item.name,
     websiteUrl: item.websiteUrl,
@@ -233,13 +236,20 @@ export async function GET() {
   });
 }
 
-async function generateDescriptionAndUpdateDb(item: {
+/**
+ * The fields a description needs, common to a freshly fetched Notion row and a
+ * row already in the database. Notion always gives an array of tags; the column
+ * is nullable, so the shared type takes the wider of the two.
+ */
+interface DescribableItem {
   id: string;
   name: string;
   websiteUrl: string;
   type: string | null;
   tags: string[] | null;
-}) {
+}
+
+async function generateDescriptionAndUpdateDb(item: DescribableItem) {
   const description = await generateDesignerDescription({
     name: item.name,
     url: item.websiteUrl,

--- a/src/app/api/notion-sync/route.ts
+++ b/src/app/api/notion-sync/route.ts
@@ -1,9 +1,17 @@
 import { NextResponse } from "next/server";
 import { fetchNotionData } from "@/lib/notion-sync";
+import { generateDesignerDescription } from "@/lib/ai-summary";
 import { db } from "@/server/db";
 import { collectables } from "@/server/db/schema";
 import { eq, inArray, isNull, or, sql } from "drizzle-orm";
 import * as cheerio from "cheerio";
+
+export const maxDuration = 60;
+
+// Rows without a description are worked through a slice at a time. Every one
+// costs a page fetch plus a model call, and the daily cron will pick up
+// whatever is left over on its next run.
+const DESCRIPTION_BACKFILL_PER_RUN = 20;
 
 async function cleanupOrphanedTags() {
   try {
@@ -95,7 +103,17 @@ export async function GET() {
         updatedAt: new Date(item.updatedAt),
         type: item.type,
         tags: item.tags,
-        ...(urlAltered ? { isReported: false, isBroken: false } : {}),
+        // A moved URL invalidates the description with it — dropping it here
+        // means a failed regeneration leaves the card blank rather than
+        // describing a page this entry no longer points at.
+        ...(urlAltered
+          ? {
+              isReported: false,
+              isBroken: false,
+              aiDescription: null,
+              aiDescriptionGeneratedAt: null,
+            }
+          : {}),
       })
       .where(eq(collectables.id, item.id));
   });
@@ -174,13 +192,70 @@ export async function GET() {
   );
   console.log("Finished fetching OG images at", new Date().toISOString());
 
+  // Describe rows whose URL is new or has moved — the old description belongs
+  // to a page this entry no longer points at — then spend what is left of the
+  // per-run budget backfilling rows that have never had one.
+  const itemsToDescribe = [...urlAlteredItems, ...newItems].map((item) => ({
+    id: item.id,
+    name: item.name,
+    websiteUrl: item.websiteUrl,
+    type: item.type,
+    tags: item.tags,
+  }));
+
+  const describedIds = new Set(itemsToDescribe.map((item) => item.id));
+  const backfillBudget = DESCRIPTION_BACKFILL_PER_RUN - itemsToDescribe.length;
+
+  if (backfillBudget > 0) {
+    const missingDescription = await db.query.collectables.findMany({
+      where: isNull(collectables.aiDescription),
+      limit: backfillBudget + describedIds.size,
+    });
+
+    itemsToDescribe.push(
+      ...missingDescription
+        .filter((item) => !describedIds.has(item.id))
+        .slice(0, backfillBudget),
+    );
+  }
+
+  console.log("Generating descriptions for", itemsToDescribe.length, "items");
+  await Promise.all(itemsToDescribe.map(generateDescriptionAndUpdateDb));
+  console.log("Finished generating descriptions at", new Date().toISOString());
+
   return NextResponse.json({
     newItems: newItems.length,
     updatedItems: updatedItems.length,
     deletedItems: deletedItems.length,
     itemsWithNullishOgImageUrl: itemsWithNullishOgImageUrl.length,
     itemsToFetchOpenGraph: itemsToFetchOpenGraph.length,
+    describedItems: itemsToDescribe.length,
   });
+}
+
+async function generateDescriptionAndUpdateDb(item: {
+  id: string;
+  name: string;
+  websiteUrl: string;
+  type: string | null;
+  tags: string[] | null;
+}) {
+  const description = await generateDesignerDescription({
+    name: item.name,
+    url: item.websiteUrl,
+    type: item.type,
+    tags: item.tags ?? [],
+  });
+
+  if (description) {
+    await db
+      .update(collectables)
+      .set({
+        aiDescription: description,
+        aiDescriptionGeneratedAt: new Date(),
+      })
+      .where(eq(collectables.id, item.id));
+  }
 }
 
 async function fetchOpenGraph(url: string): Promise<string | null> {

--- a/src/app/api/notion-sync/route.ts
+++ b/src/app/api/notion-sync/route.ts
@@ -212,6 +212,10 @@ export async function GET() {
   if (backfillBudget > 0) {
     const missingDescription = await db.query.collectables.findMany({
       where: isNull(collectables.aiDescription),
+      // Never-attempted rows first, then the longest-untried. Without an
+      // ordering Postgres is free to hand back the same failing rows every
+      // run, and the backfill stalls short of the rows behind them.
+      orderBy: [sql`${collectables.aiDescriptionGeneratedAt} ASC NULLS FIRST`],
       limit: backfillBudget + describedIds.size,
     });
 
@@ -257,15 +261,18 @@ async function generateDescriptionAndUpdateDb(item: DescribableItem) {
     tags: item.tags ?? [],
   });
 
-  if (description) {
-    await db
-      .update(collectables)
-      .set({
-        aiDescription: description,
-        aiDescriptionGeneratedAt: new Date(),
-      })
-      .where(eq(collectables.id, item.id));
-  }
+  // The timestamp records the attempt, not the result, so it is stamped even
+  // when nothing came back. A row with no description but a timestamp is one
+  // that has been tried and failed — the backfill sorts on this so a handful
+  // of sites that can never be scraped move to the back of the queue instead
+  // of being retried forever while the rest go undescribed.
+  await db
+    .update(collectables)
+    .set({
+      ...(description ? { aiDescription: description } : {}),
+      aiDescriptionGeneratedAt: new Date(),
+    })
+    .where(eq(collectables.id, item.id));
 }
 
 async function fetchOpenGraph(url: string): Promise<string | null> {

--- a/src/components/collectable-card.tsx
+++ b/src/components/collectable-card.tsx
@@ -168,9 +168,17 @@ export function CollectableCard({ collectable }: CollectableCardProps) {
         )}
       </div>
 
-      <h2 className="mt-3 text-center font-medium text-neutral-700">
-        {collectable.name}
-      </h2>
+      <div className="mt-3 flex flex-col items-center gap-1.5">
+        <h2 className="text-center font-medium text-neutral-700">
+          {collectable.name}
+        </h2>
+
+        {collectable.aiDescription && (
+          <p className="text-balance text-center text-sm leading-snug text-neutral-600">
+            {collectable.aiDescription}
+          </p>
+        )}
+      </div>
 
       {/* Covers the whole card — artwork and name are one click target. Sits
           above the media so it actually receives the click. */}

--- a/src/env.js
+++ b/src/env.js
@@ -14,9 +14,10 @@ export const env = createEnv({
     NOTION_DATABASE_ID: z.string(),
     NOTION_API_KEY: z.string(),
 
-    // Case study support is optional: the site builds and serves the designer
-    // view without any of these. Missing credentials disable the case study
-    // sync rather than failing the build.
+    // All optional: the site builds and serves both views without any of them.
+    // Missing credentials switch off the feature that needs them — the case
+    // study sync, or the AI blurbs on either grid — rather than failing the
+    // build.
     NOTION_CASE_STUDY_DATABASE_ID: z.string().optional(),
     ANTHROPIC_API_KEY: z.string().optional(),
     BLOB_READ_WRITE_TOKEN: z.string().optional(),

--- a/src/lib/ai-summary.ts
+++ b/src/lib/ai-summary.ts
@@ -1,9 +1,27 @@
 import Anthropic from "@anthropic-ai/sdk";
 import * as cheerio from "cheerio";
 
-// Short summaries only — this is a card caption, not an article.
+// Short summaries only — these are card captions, not articles.
 const MAX_TOKENS = 300;
 const MAX_SOURCE_CHARS = 12_000;
+
+const SHARED_STYLE =
+  "Write plainly and concretely. Do not use marketing language, do not " +
+  "start with the name, and reply with the summary only.";
+
+const CASE_STUDY_SYSTEM =
+  "You write short blurbs for a curated gallery of design work. " +
+  "Given source material about a project, reply with one or two " +
+  "sentences describing what it is and what makes the design notable. " +
+  SHARED_STYLE;
+
+const DESIGNER_SYSTEM =
+  "You write short blurbs for a curated directory of designers and design " +
+  "studios. Given source material from someone's own site, reply with one " +
+  "or two sentences describing who they are and the kind of work they do. " +
+  "Only state what the source material supports — if it is too thin to say " +
+  "anything specific, reply with the word NONE. " +
+  SHARED_STYLE;
 
 interface SummaryInput {
   name: string;
@@ -11,6 +29,13 @@ interface SummaryInput {
   sourceText: string | null;
   types: string[];
   industries: string[];
+}
+
+interface DesignerInput {
+  name: string;
+  url: string;
+  type: string | null;
+  tags: string[];
 }
 
 /**
@@ -32,6 +57,51 @@ async function fetchPageText(url: string): Promise<string | null> {
     return text === "" ? null : text.slice(0, MAX_SOURCE_CHARS);
   } catch (error) {
     console.error("Error fetching page text for", url, error);
+    return null;
+  }
+}
+
+/**
+ * One model call, shared by both kinds of blurb.
+ *
+ * `label` only ever reaches the logs; it identifies the row being summarised
+ * when a fetch or a call fails partway through a sync.
+ */
+async function writeBlurb({
+  system,
+  context,
+  source,
+  label,
+}: {
+  system: string;
+  context: string;
+  source: string;
+  label: string;
+}): Promise<string | null> {
+  try {
+    const anthropic = new Anthropic();
+
+    const message = await anthropic.messages.create({
+      model: "claude-haiku-4-5",
+      max_tokens: MAX_TOKENS,
+      system,
+      messages: [
+        {
+          role: "user",
+          content: `${context}\n\nSource material:\n${source}`,
+        },
+      ],
+    });
+
+    const blurb = message.content
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("")
+      .trim();
+
+    return blurb === "" ? null : blurb;
+  } catch (error) {
+    console.error("Error generating summary for", label, error);
     return null;
   }
 }
@@ -71,35 +141,58 @@ export async function generateSummary({
     .filter(Boolean)
     .join("\n");
 
-  try {
-    const anthropic = new Anthropic();
+  return writeBlurb({
+    system: CASE_STUDY_SYSTEM,
+    context,
+    source,
+    label: name,
+  });
+}
 
-    const message = await anthropic.messages.create({
-      model: "claude-haiku-4-5",
-      max_tokens: MAX_TOKENS,
-      system:
-        "You write short blurbs for a curated gallery of design work. " +
-        "Given source material about a project, reply with one or two " +
-        "sentences describing what it is and what makes the design notable. " +
-        "Write plainly and concretely. Do not use marketing language, do not " +
-        "start with the project name, and reply with the summary only.",
-      messages: [
-        {
-          role: "user",
-          content: `${context}\n\nSource material:\n${source}`,
-        },
-      ],
-    });
-
-    const summary = message.content
-      .filter((block) => block.type === "text")
-      .map((block) => block.text)
-      .join("")
-      .trim();
-
-    return summary === "" ? null : summary;
-  } catch (error) {
-    console.error("Error generating summary for", name, error);
+/**
+ * Writes a one or two sentence description of a designer.
+ *
+ * The only source is the linked site itself — the designer database has no
+ * equivalent of the case studies' captured source text. Portfolios that render
+ * client-side scrape to nothing, and those rows simply keep no description
+ * rather than getting an invented one.
+ */
+export async function generateDesignerDescription({
+  name,
+  url,
+  type,
+  tags,
+}: DesignerInput): Promise<string | null> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.warn("ANTHROPIC_API_KEY not set — skipping description for", name);
     return null;
   }
+
+  const source = await fetchPageText(url);
+
+  if (!source) {
+    console.warn("No source material to describe", name);
+    return null;
+  }
+
+  const context = [
+    `Designer name: ${name}`,
+    `URL: ${url}`,
+    type ? `Type: ${type}` : null,
+    tags.length > 0 ? `Works in: ${tags.join(", ")}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const description = await writeBlurb({
+    system: DESIGNER_SYSTEM,
+    context,
+    source,
+    label: name,
+  });
+
+  // A page can load fine and still say nothing about its owner — a splash
+  // screen, a cookie wall, a holding page. The model flags those instead of
+  // padding out a description from the tags alone.
+  return description === "NONE" ? null : description;
 }

--- a/src/lib/ai-summary.ts
+++ b/src/lib/ai-summary.ts
@@ -5,6 +5,11 @@ import * as cheerio from "cheerio";
 const MAX_TOKENS = 300;
 const MAX_SOURCE_CHARS = 12_000;
 
+// A sync describes a batch of unrelated sites at once under a 60s ceiling, so
+// one server that accepts the connection and then never answers would cost the
+// whole run. Better to give up on it and take the row next time.
+const FETCH_TIMEOUT_MS = 10_000;
+
 const SHARED_STYLE =
   "Write plainly and concretely. Do not use marketing language, do not " +
   "start with the name, and reply with the summary only.";
@@ -47,7 +52,9 @@ interface DesignerInput {
  */
 async function fetchPageText(url: string): Promise<string | null> {
   try {
-    const response = await fetch(url);
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
     if (!response.ok) return null;
 
     const $ = cheerio.load(await response.text());

--- a/src/server/api/routers/collectable.ts
+++ b/src/server/api/routers/collectable.ts
@@ -73,6 +73,7 @@ export const collectableRouter = createTRPCRouter({
           createdAt: collectables.createdAt,
           websiteUrl: collectables.websiteUrl,
           ogImageUrl: collectables.ogImageUrl,
+          aiDescription: collectables.aiDescription,
         })
         .from(collectables)
         .limit(limit + 1)

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -32,6 +32,13 @@ export const collectables = createTable(
     ogImageLastFetchedAt: timestamp("og_image_last_fetched_at", {
       withTimezone: true,
     }),
+
+    // Written by the sync from the designer's own site — see `ai-summary.ts`.
+    aiDescription: text("ai_description"),
+    aiDescriptionGeneratedAt: timestamp("ai_description_generated_at", {
+      withTimezone: true,
+    }),
+
     isReported: boolean("is_reported").notNull().default(false),
     isBroken: boolean("is_broken").notNull().default(false),
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [{ "name": "next" }],
     "incremental": true,
 
-    /* Path Aliases */
-    "baseUrl": ".",
+    /* Path Aliases — relative to this file, so no `baseUrl` is needed. Setting
+       one makes `tsc` abort with a deprecation error instead of type checking. */
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary
Extends the AI summarization system to generate descriptions for designer directory entries, not just case studies. Designers now display a short AI-generated blurb under their name on the card, similar to how case studies work.

## Key Changes

- **Refactored AI summarization logic**: Extracted common model call logic into a reusable `writeBlurb()` function that both case study and designer summaries use
- **Added designer description generation**: New `generateDesignerDescription()` function that fetches a designer's website and generates a one or two sentence description using Claude
- **Extended database schema**: Added `aiDescription` and `aiDescriptionGeneratedAt` columns to the `collectables` table to store generated descriptions
- **Updated sync process**: Modified the Notion sync to generate descriptions for designers with new or moved URLs, then backfill up to 20 descriptions per run for entries that have never had one
- **UI updates**: Designer cards now display the AI description below the name when available
- **Improved prompt engineering**: Separated shared style guidance into `SHARED_STYLE` constant and created distinct system prompts for case studies vs. designers, with the designer prompt including a "NONE" fallback for pages that don't provide enough information
- **URL change handling**: When a designer's URL changes, the old description is cleared to avoid describing a page the entry no longer points to
- **Environment documentation**: Updated `.env.example` to clarify that `ANTHROPIC_API_KEY` is now optional and used for both case study and designer descriptions

## Notable Implementation Details

- The designer description generation gracefully handles pages that load but provide no useful content (splash screens, cookie walls, etc.) by having the model return "NONE", which the code treats as no description rather than padding with generic information
- Description backfilling is rate-limited to 20 items per sync run to avoid excessive API usage, with the daily cron picking up remaining items on subsequent runs
- The implementation maintains backward compatibility—both syncs work normally without the API key, just without generating descriptions

https://claude.ai/code/session_01GAoUPRfwtoNpMhyG2TCPYg