### PR TITLE
Make the profile sync reach every row, and say which it cannot read

### DIFF
--- a/src/app/api/notion-sync/route.ts
+++ b/src/app/api/notion-sync/route.ts
@@ -3,15 +3,52 @@ import { fetchNotionData } from "@/lib/notion-sync";
 import { generateDesignerProfile } from "@/lib/ai-summary";
 import { db } from "@/server/db";
 import { collectables } from "@/server/db/schema";
-import { eq, inArray, isNull, or, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import * as cheerio from "cheerio";
 
 export const maxDuration = 60;
 
-// Rows without a profile are worked through a slice at a time. Every one costs
-// a page fetch plus a model call, and the daily cron will pick up whatever is
-// left over on its next run.
+// Rows with something still missing are worked through a slice at a time. Every
+// one costs a page fetch plus a model call, and the daily cron picks up what is
+// left over on its next run. `?profiles=` raises the slice for a run kicked off
+// by hand, which is how a directory gets swept in one go rather than over a
+// fortnight of crons.
+//
+// The ceiling exists because the whole slice is fetched and called in parallel
+// under a 60s function: batching it instead would be gentler but could not
+// finish, and a row whose call is rate-limited is left unstamped to come round
+// again rather than being recorded as looked at.
 const PROFILE_BACKFILL_PER_RUN = 20;
+const PROFILE_BACKFILL_MAX = 100;
+
+// How long a row that came back incomplete is left alone before being read
+// again. Something missing is not the same as something absent — a site that
+// says nothing about where its owner works today may say so next month — but
+// the two are indistinguishable from here, so incomplete rows come round on a
+// cooldown instead of consuming every run's budget in perpetuity. A row with
+// all four fields is never read again.
+const PROFILE_RETRY_DAYS = 30;
+
+/**
+ * Rows worth spending a fetch and a call on: something is still missing, and
+ * either they have never been read or their last reading has gone stale.
+ */
+function incompleteProfiles() {
+  return and(
+    or(
+      isNull(collectables.aiDescription),
+      isNull(collectables.location),
+      isNull(collectables.company),
+      isNull(collectables.title),
+    ),
+    or(
+      isNull(collectables.profileGeneratedAt),
+      sql`${collectables.profileGeneratedAt} < NOW() - INTERVAL '${sql.raw(
+        `${PROFILE_RETRY_DAYS} days`,
+      )}'`,
+    ),
+  );
+}
 
 async function cleanupOrphanedTags() {
   try {
@@ -58,7 +95,15 @@ async function cleanupOrphanedTags() {
   }
 }
 
-export async function GET() {
+export async function GET(request: Request) {
+  const requested = Number(
+    new URL(request.url).searchParams.get("profiles") ?? "",
+  );
+  const profileBudget =
+    Number.isFinite(requested) && requested > 0
+      ? Math.min(Math.trunc(requested), PROFILE_BACKFILL_MAX)
+      : PROFILE_BACKFILL_PER_RUN;
+
   const trueItems = await fetchNotionData();
 
   const dbItems = await db.query.collectables.findMany();
@@ -211,19 +256,14 @@ export async function GET() {
   }));
 
   const profiledIds = new Set(itemsToProfile.map((item) => item.id));
-  const backfillBudget = PROFILE_BACKFILL_PER_RUN - itemsToProfile.length;
+  const backfillBudget = profileBudget - itemsToProfile.length;
 
   if (backfillBudget > 0) {
     const missingProfile = await db.query.collectables.findMany({
-      // Rows described before the profile fields existed have a description and
-      // no `profileGeneratedAt`, so the second clause sweeps them up once.
-      where: or(
-        isNull(collectables.aiDescription),
-        isNull(collectables.profileGeneratedAt),
-      ),
-      // Never-attempted rows first, then the longest-untried. Without an
-      // ordering Postgres is free to hand back the same failing rows every
-      // run, and the backfill stalls short of the rows behind them.
+      where: incompleteProfiles(),
+      // Never-read rows first, then the longest-unread. Without an ordering
+      // Postgres is free to hand back the same rows every run, and the backfill
+      // stalls short of the rows behind them.
       orderBy: [sql`${collectables.profileGeneratedAt} ASC NULLS FIRST`],
       limit: backfillBudget + profiledIds.size,
     });
@@ -236,8 +276,17 @@ export async function GET() {
   }
 
   console.log("Generating profiles for", itemsToProfile.length, "items");
-  await Promise.all(itemsToProfile.map(generateProfileAndUpdateDb));
+  const profileResults = await Promise.all(
+    itemsToProfile.map(generateProfileAndUpdateDb),
+  );
   console.log("Finished generating profiles at", new Date().toISOString());
+
+  // What is still outstanding once this run has written its rows, so a sweep
+  // by hand can be repeated until it reaches zero rather than guessed at.
+  const [remaining] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(collectables)
+    .where(incompleteProfiles());
 
   return NextResponse.json({
     newItems: newItems.length,
@@ -245,7 +294,9 @@ export async function GET() {
     deletedItems: deletedItems.length,
     itemsWithNullishOgImageUrl: itemsWithNullishOgImageUrl.length,
     itemsToFetchOpenGraph: itemsToFetchOpenGraph.length,
-    profiledItems: itemsToProfile.length,
+    profilesRead: profileResults.filter(Boolean).length,
+    profilesFailed: profileResults.filter((read) => !read).length,
+    profilesRemaining: remaining?.count ?? 0,
   });
 }
 
@@ -262,7 +313,14 @@ interface DescribableItem {
   tags: string[] | null;
 }
 
-async function generateProfileAndUpdateDb(item: DescribableItem) {
+/**
+ * Reads one row's site and writes back what it found. Answers whether the row
+ * was actually read, which is what the run reports and what decides whether the
+ * row waits out the retry window or comes back on the next run.
+ */
+async function generateProfileAndUpdateDb(
+  item: DescribableItem,
+): Promise<boolean> {
   const profile = await generateDesignerProfile({
     name: item.name,
     url: item.websiteUrl,
@@ -270,11 +328,15 @@ async function generateProfileAndUpdateDb(item: DescribableItem) {
     tags: item.tags ?? [],
   });
 
-  // The timestamps record the attempt, not the result, so they are stamped even
-  // when nothing came back. A row with no description but a timestamp is one
-  // that has been tried and failed — the backfill sorts on this so a handful
-  // of sites that can never be scraped move to the back of the queue instead
-  // of being retried forever while the rest go unread.
+  // An attempt that never got to look at the page leaves the row exactly as it
+  // was, timestamp included. Stamping here would put a row that was merely
+  // rate-limited into the retry window alongside the ones that genuinely have
+  // nothing to give.
+  if (!profile) return false;
+
+  // The timestamps record the reading, not the result, so they are stamped even
+  // when the page said nothing. That is what moves a site which cannot be
+  // scraped out of the way of the rows behind it.
   //
   // Fields that came back empty are left alone rather than written as null: a
   // site that has since dropped its "currently at" line shouldn't blank out the
@@ -290,6 +352,8 @@ async function generateProfileAndUpdateDb(item: DescribableItem) {
       profileGeneratedAt: new Date(),
     })
     .where(eq(collectables.id, item.id));
+
+  return true;
 }
 
 async function fetchOpenGraph(url: string): Promise<string | null> {

--- a/src/app/api/notion-sync/route.ts
+++ b/src/app/api/notion-sync/route.ts
@@ -29,18 +29,29 @@ const PROFILE_BACKFILL_MAX = 100;
 // all four fields is never read again.
 const PROFILE_RETRY_DAYS = 30;
 
-/**
- * Rows worth spending a fetch and a call on: something is still missing, and
- * either they have never been read or their last reading has gone stale.
- */
+/** Rows with something still missing, whatever their last reading said. */
 function incompleteProfiles() {
+  return or(
+    isNull(collectables.aiDescription),
+    isNull(collectables.location),
+    isNull(collectables.company),
+    isNull(collectables.title),
+  );
+}
+
+/**
+ * Rows worth spending a fetch and a call on now: something is still missing,
+ * and either they have never been read or their last reading has gone stale.
+ *
+ * `ignoreCooldown` is what `?refresh=1` sets. Every row is inside the window
+ * for a month after a sweep, so without it an improvement to what the model is
+ * asked for could not reach a single row until the window ran out.
+ */
+function profilesToRead(ignoreCooldown: boolean) {
+  if (ignoreCooldown) return incompleteProfiles();
+
   return and(
-    or(
-      isNull(collectables.aiDescription),
-      isNull(collectables.location),
-      isNull(collectables.company),
-      isNull(collectables.title),
-    ),
+    incompleteProfiles(),
     or(
       isNull(collectables.profileGeneratedAt),
       sql`${collectables.profileGeneratedAt} < NOW() - INTERVAL '${sql.raw(
@@ -96,13 +107,13 @@ async function cleanupOrphanedTags() {
 }
 
 export async function GET(request: Request) {
-  const requested = Number(
-    new URL(request.url).searchParams.get("profiles") ?? "",
-  );
+  const params = new URL(request.url).searchParams;
+  const requested = Number(params.get("profiles") ?? "");
   const profileBudget =
     Number.isFinite(requested) && requested > 0
       ? Math.min(Math.trunc(requested), PROFILE_BACKFILL_MAX)
       : PROFILE_BACKFILL_PER_RUN;
+  const ignoreCooldown = params.get("refresh") === "1";
 
   const trueItems = await fetchNotionData();
 
@@ -260,7 +271,7 @@ export async function GET(request: Request) {
 
   if (backfillBudget > 0) {
     const missingProfile = await db.query.collectables.findMany({
-      where: incompleteProfiles(),
+      where: profilesToRead(ignoreCooldown),
       // Never-read rows first, then the longest-unread. Without an ordering
       // Postgres is free to hand back the same rows every run, and the backfill
       // stalls short of the rows behind them.
@@ -281,12 +292,18 @@ export async function GET(request: Request) {
   );
   console.log("Finished generating profiles at", new Date().toISOString());
 
-  // What is still outstanding once this run has written its rows, so a sweep
-  // by hand can be repeated until it reaches zero rather than guessed at.
-  const [remaining] = await db
-    .select({ count: sql<number>`count(*)::int` })
-    .from(collectables)
-    .where(incompleteProfiles());
+  // Where the directory stands once this run has written its rows. `eligible`
+  // is what another run would pick up right now and `incomplete` is what is
+  // actually missing — they differ by the cooldown, and reporting only the
+  // first would read as finished when it means everything was read recently.
+  // `unreadable` is the part no further reading can fix.
+  const [standing] = await db
+    .select({
+      eligible: sql<number>`count(*) FILTER (WHERE ${profilesToRead(false)})::int`,
+      incomplete: sql<number>`count(*) FILTER (WHERE ${incompleteProfiles()})::int`,
+      unreadable: sql<number>`count(*) FILTER (WHERE ${collectables.profilePageRead} = false)::int`,
+    })
+    .from(collectables);
 
   return NextResponse.json({
     newItems: newItems.length,
@@ -296,7 +313,9 @@ export async function GET(request: Request) {
     itemsToFetchOpenGraph: itemsToFetchOpenGraph.length,
     profilesRead: profileResults.filter(Boolean).length,
     profilesFailed: profileResults.filter((read) => !read).length,
-    profilesRemaining: remaining?.count ?? 0,
+    profilesEligible: standing?.eligible ?? 0,
+    profilesIncomplete: standing?.incomplete ?? 0,
+    profilesUnreadable: standing?.unreadable ?? 0,
   });
 }
 
@@ -350,6 +369,7 @@ async function generateProfileAndUpdateDb(
       ...(profile.title ? { title: profile.title } : {}),
       aiDescriptionGeneratedAt: new Date(),
       profileGeneratedAt: new Date(),
+      profilePageRead: profile.pageRead,
     })
     .where(eq(collectables.id, item.id));
 

--- a/src/app/api/notion-sync/route.ts
+++ b/src/app/api/notion-sync/route.ts
@@ -159,21 +159,14 @@ export async function GET(request: Request) {
         updatedAt: new Date(item.updatedAt),
         type: item.type,
         tags: item.tags,
-        // A moved URL invalidates the profile with it — dropping it here means
-        // a failed regeneration leaves the card blank rather than describing a
-        // page this entry no longer points at.
-        ...(urlAltered
-          ? {
-              isReported: false,
-              isBroken: false,
-              aiDescription: null,
-              aiDescriptionGeneratedAt: null,
-              location: null,
-              company: null,
-              title: null,
-              profileGeneratedAt: null,
-            }
-          : {}),
+        // A moved URL clears the link flags, since the complaint was about an
+        // address this entry no longer uses. The profile is left standing: the
+        // row is read again below whatever else happens this run, and anything
+        // the new page gives overwrites it field by field. Blanking it here
+        // instead would trade a description that is usually still true — most
+        // moved URLs are the same designer on a new host — for an empty card
+        // whenever the new page cannot be read.
+        ...(urlAltered ? { isReported: false, isBroken: false } : {}),
       })
       .where(eq(collectables.id, item.id));
   });

--- a/src/lib/ai-summary.ts
+++ b/src/lib/ai-summary.ts
@@ -101,6 +101,13 @@ interface DesignerInput {
 }
 
 export interface DesignerProfile {
+  /**
+   * Whether the site yielded any text to read. False separates a portfolio
+   * that cannot be scraped from one that was read and simply says nothing
+   * about its owner — the fields below are null either way, and only the
+   * second kind is worth reading again the same way.
+   */
+  pageRead: boolean;
   description: string | null;
   location: string | null;
   company: string | null;
@@ -112,7 +119,16 @@ export interface DesignerProfile {
 // the rest. Only an attempt that never got to look — no key, a call that
 // errored, a rate limit — returns null, and those rows are left unstamped so
 // the next run picks them straight back up.
-const NOTHING_ON_THE_PAGE: DesignerProfile = {
+const UNREADABLE_PAGE: DesignerProfile = {
+  pageRead: false,
+  description: null,
+  location: null,
+  company: null,
+  title: null,
+};
+
+const READ_BUT_EMPTY: DesignerProfile = {
+  pageRead: true,
   description: null,
   location: null,
   company: null,
@@ -275,7 +291,7 @@ export async function generateDesignerProfile({
 
   if (!source) {
     console.warn("No source material to describe", name);
-    return NOTHING_ON_THE_PAGE;
+    return UNREADABLE_PAGE;
   }
 
   const context = [
@@ -310,7 +326,7 @@ export async function generateDesignerProfile({
     // as looked at rather than as something to retry.
     if (message.stop_reason === "max_tokens") {
       console.error("Profile cut off by the token limit for", name);
-      return NOTHING_ON_THE_PAGE;
+      return READ_BUT_EMPTY;
     }
 
     const toolUse = message.content.find((block) => block.type === "tool_use");
@@ -323,6 +339,7 @@ export async function generateDesignerProfile({
     const profile = toolUse.input as Record<string, unknown>;
 
     return {
+      pageRead: true,
       description: readDetail(profile.description, MAX_DESCRIPTION_CHARS),
       location: readDetail(profile.location),
       company: readDetail(profile.company),

--- a/src/lib/ai-summary.ts
+++ b/src/lib/ai-summary.ts
@@ -107,7 +107,12 @@ export interface DesignerProfile {
   title: string | null;
 }
 
-const EMPTY_PROFILE: DesignerProfile = {
+// A page that scrapes to nothing is an answer: the site will read the same way
+// tomorrow, so the row counts as looked at and waits out the retry window with
+// the rest. Only an attempt that never got to look — no key, a call that
+// errored, a rate limit — returns null, and those rows are left unstamped so
+// the next run picks them straight back up.
+const NOTHING_ON_THE_PAGE: DesignerProfile = {
   description: null,
   location: null,
   company: null,
@@ -251,23 +256,26 @@ function readDetail(value: unknown, max = MAX_DETAIL_CHARS): string | null {
  * same page, and a second call would double the cost of every row the sync
  * touches. Any individual field can be null — a page can load fine and still
  * be a splash screen, a cookie wall, or a holding page.
+ *
+ * Returns null when the attempt failed rather than came back empty, which is
+ * the caller's signal to leave the row unstamped and try it again next run.
  */
 export async function generateDesignerProfile({
   name,
   url,
   type,
   tags,
-}: DesignerInput): Promise<DesignerProfile> {
+}: DesignerInput): Promise<DesignerProfile | null> {
   if (!process.env.ANTHROPIC_API_KEY) {
     console.warn("ANTHROPIC_API_KEY not set — skipping profile for", name);
-    return EMPTY_PROFILE;
+    return null;
   }
 
   const source = await fetchPageText(url);
 
   if (!source) {
     console.warn("No source material to describe", name);
-    return EMPTY_PROFILE;
+    return NOTHING_ON_THE_PAGE;
   }
 
   const context = [
@@ -298,16 +306,18 @@ export async function generateDesignerProfile({
 
     // A call cut off at the token ceiling leaves the tool's JSON half-written,
     // and a description that stops mid-sentence is worse on a card than none.
+    // The same page will run the model just as long next time, so this counts
+    // as looked at rather than as something to retry.
     if (message.stop_reason === "max_tokens") {
       console.error("Profile cut off by the token limit for", name);
-      return EMPTY_PROFILE;
+      return NOTHING_ON_THE_PAGE;
     }
 
     const toolUse = message.content.find((block) => block.type === "tool_use");
 
     if (!toolUse) {
       console.error("No profile returned for", name);
-      return EMPTY_PROFILE;
+      return null;
     }
 
     const profile = toolUse.input as Record<string, unknown>;
@@ -320,6 +330,6 @@ export async function generateDesignerProfile({
     };
   } catch (error) {
     console.error("Error generating profile for", name, error);
-    return EMPTY_PROFILE;
+    return null;
   }
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -50,6 +50,13 @@ export const collectables = createTable(
     profileGeneratedAt: timestamp("profile_generated_at", {
       withTimezone: true,
     }),
+    // Whether the last pass got any text off the page at all, which is what
+    // separates the two reasons a field above is null. False is a site that
+    // cannot be read — rendered client-side, or behind a block — and says
+    // nothing about the designer. True means the page was read and simply does
+    // not mention where they are or who they work for, which no amount of
+    // re-reading will change. Null is a row no pass has reached yet.
+    profilePageRead: boolean("profile_page_read"),
 
     isReported: boolean("is_reported").notNull().default(false),
     isBroken: boolean("is_broken").notNull().default(false),


### PR DESCRIPTION
Follow-up to #20, which added the profile fields. Running the sync repeatedly did not fill them in, and this is why.

## Run this before deploying

It adds a nullable column, so the SQL and the code can go in either order:

```sql
ALTER TABLE "cur8d_collectable"
  ADD COLUMN IF NOT EXISTS "profile_page_read" boolean;
```

Applied twice against a local database with no complaint.

## Why re-running did not help

Two separate causes.

**Described rows were unreachable.** The backfill selected on `aiDescription IS NULL` alone. A designer whose site described them but never stated a location had both a description and a `profileGeneratedAt` timestamp, so they stopped matching the query entirely. No number of re-runs could reach them.

**Dead rows monopolised every run.** The sites that render client-side scrape to nothing, never gain a description, and so matched forever. Each run spent its whole budget cycling through them, and the daily cron would have kept spending 20 model calls a day on pages that will never parse.

## Reaching every row

- **Select on anything missing**, not the description alone, which puts the described-but-incomplete rows back in range.
- **A 30-day cooldown** before a row that has been read is read again; a row with all four fields is never read again. Something missing is not the same as something absent — a site may add a "currently at" line next month — but the two cannot be told apart from here, so the cooldown bounds the cost of assuming the former.
- **Separate a failed attempt from an empty answer.** `generateDesignerProfile` returns `null` when it never got to look (no API key, an errored or rate-limited call) versus an empty profile for a page that genuinely says nothing. Only the second is stamped. Without this, the cooldown would lock a transient rate limit out for a month.
- **`?profiles=`** raises the per-run slice to a ceiling of 100, so a sweep by hand covers the directory in one request rather than five. The ceiling exists because the slice is fetched and called in parallel under a 60s function.
- **`?refresh=1`** ignores the cooldown. After a sweep every row sits inside the window for a month, so without this the next improvement to what the model is asked for could not reach a single row until it expired.

## Saying which rows cannot be read

`null` meant two things at once: a site that cannot be scraped, and a site that was read fine and simply never says where its owner is. They want opposite treatment — the first is a fetch problem, the second is a finished answer.

`profile_page_read` records which. On the current directory of 100 designers that splits the 61 rows with no location into **21** whose sites give nothing and **40** that were read and stay silent.

The run's report follows the same split. `profilesRemaining` was one number doing two jobs, and read as finished when it meant everything had been read recently — after a sweep it showed zero while 61 rows were still missing fields. It is now:

- `profilesEligible` — what another run would pick up now
- `profilesIncomplete` — what is actually missing, cooldown aside
- `profilesUnreadable` — the part no further reading can fix

## Verification

Checked the selection against a local Postgres seeded with a row of every kind: never read, read yesterday, read 40 days ago, complete, and unreadable at both ages. A normal run takes the never-read and the two stale ones, oldest first; `?refresh=1` takes all five incomplete rows; the three counts come back 3 / 5 / 2 as expected. Also confirmed the generated SQL renders the interval literal correctly and that the counts come back as numbers rather than strings.

Typecheck, lint, and build pass against the current `staging`.

## Deliberately not included

No invented fallback values. A placeholder location on a public directory is a guess presented as fact, and a wrong city is worse than none — the card already hides an empty field rather than showing a gap. The honest fallback for the 40 readable-but-silent rows is a human one, e.g. an optional location property in Notion that the sync prefers over what it can infer. Worth discussing separately.

`fetchOpenGraph` still has no timeout, unlike `fetchPageText`. The 29 rows with no OG image are re-fetched every run with nothing bounding them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dka9aiJayt7JyRSa1YzGCB