### PR TITLE
Migrate Google Analytics to Next.js third-parties package

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,13 @@ NOTION_CASE_STUDY_DATABASE_ID="944872db-d32d-4735-b7c6-d466fe57fce2"
 # hand for local runs of `npm run ingest:video`.
 BLOB_READ_WRITE_TOKEN="vercel_blob_rw_1234567890"
 
+# --- Google Analytics --------------------------------------------------------
+# Optional. The GA4 measurement ID for the cur8d.club web stream. Set it only
+# where the traffic should be counted — production on Vercel. Left unset, the
+# tag is never loaded, so local runs and preview deploys stay out of the
+# property.
+NEXT_PUBLIC_GA_MEASUREMENT_ID="G-1234567890"
+
 # Example:
 # SERVERVAR="foo"
 # NEXT_PUBLIC_CLIENTVAR="bar"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
+        "@next/third-parties": "^15.0.7",
         "@notionhq/client": "^2.3.0",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-dialog": "^1.1.6",
@@ -1809,6 +1810,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "15.0.7",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-15.0.7.tgz",
+      "integrity": "sha512-KAaoVPK4Op26VG8BHtcg9Vjd2AvbACszIyHhs34Sb+kNlk/QyfbHpyUp7b3E2tLUpm+KrEzNTjkP1FCFXcEFEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^18.2.0 || 19.0.0-rc-66855b96-20241106 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -9497,6 +9511,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/throttle-debounce": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.115.0",
+    "@next/third-parties": "^15.0.7",
     "@notionhq/client": "^2.3.0",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-dialog": "^1.1.6",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,8 +7,9 @@ import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { TRPCReactProvider } from "@/trpc/react";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import Script from "next/script";
 import { Analytics } from "@vercel/analytics/next";
+import { GoogleAnalytics } from "@next/third-parties/google";
+import { env } from "@/env";
 
 const manrope = Manrope({
   subsets: ["latin"],
@@ -53,19 +54,6 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${manrope.className}`}>
       <head>
-        {/* Google Analytics */}
-        <Script
-          src="https://www.googletagmanager.com/gtag/js?id=G-W8DDNEEV6L"
-          strategy="afterInteractive"
-        />
-        <Script id="google-analytics" strategy="afterInteractive">
-          {`
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', 'G-W8DDNEEV6L');
-          `}
-        </Script>
         <meta
           httpEquiv="Content-Security-Policy"
           content="script-src 'self' 'unsafe-eval' 'unsafe-inline' https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https: http:; font-src 'self' https://fonts.gstatic.com data:;"
@@ -81,6 +69,11 @@ export default function RootLayout({
           </TRPCReactProvider>
         </NuqsAdapter>
         <Analytics />
+        {/* Only mounted where the measurement ID is set, so local dev and
+            preview deploys stay out of the production property. */}
+        {env.NEXT_PUBLIC_GA_MEASUREMENT_ID && (
+          <GoogleAnalytics gaId={env.NEXT_PUBLIC_GA_MEASUREMENT_ID} />
+        )}
       </body>
     </html>
   );

--- a/src/env.js
+++ b/src/env.js
@@ -29,7 +29,10 @@ export const env = createEnv({
    * `NEXT_PUBLIC_`.
    */
   client: {
-    // NEXT_PUBLIC_CLIENTVAR: z.string(),
+    // Optional so that local dev and preview deploys, which have no reason to
+    // report into the production property, simply run without Google
+    // Analytics rather than failing the build.
+    NEXT_PUBLIC_GA_MEASUREMENT_ID: z.string().startsWith("G-").optional(),
   },
 
   /**
@@ -44,7 +47,7 @@ export const env = createEnv({
     BLOB_READ_WRITE_TOKEN: process.env.BLOB_READ_WRITE_TOKEN,
     DATABASE_URL: process.env.DATABASE_URL,
     NODE_ENV: process.env.NODE_ENV,
-    // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
+    NEXT_PUBLIC_GA_MEASUREMENT_ID: process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially


### PR DESCRIPTION
## Summary
Refactored Google Analytics integration to use the official `@next/third-parties` package instead of manual Script components, with support for optional configuration in non-production environments.

## Key Changes
- Replaced manual Google Analytics Script components with `GoogleAnalytics` component from `@next/third-parties/google`
- Made GA measurement ID optional via environment variable `NEXT_PUBLIC_GA_MEASUREMENT_ID`
- Added conditional rendering so Google Analytics only loads when the measurement ID is configured
- Updated environment configuration to support optional GA setup for local development and preview deployments
- Added `@next/third-parties` dependency to package.json

## Implementation Details
- The Google Analytics component is now only mounted when `env.NEXT_PUBLIC_GA_MEASUREMENT_ID` is set, preventing local dev and preview deploys from reporting to the production GA property
- Environment variable validation uses `z.string().startsWith("G-").optional()` to ensure valid GA4 measurement IDs when provided
- Removed hardcoded measurement ID (`G-W8DDNEEV6L`) and manual gtag initialization script in favor of the declarative Next.js component approach
- Added explanatory comments documenting the optional nature of the configuration

https://claude.ai/code/session_01DHNJpotCNsBotuVjceaXkr