### PR TITLE
Add free-text search to designer and case study listings

### DIFF
--- a/src/components/case-study-card.tsx
+++ b/src/components/case-study-card.tsx
@@ -7,6 +7,7 @@ import { type api as serverApi } from "@/trpc/server";
 import { cn } from "@/lib/utils";
 import { badgeScaleForPointer, type CoverBox } from "@/lib/cursor-badge";
 import { ImagePlaceholder } from "./image-placeholder";
+import { Highlight } from "./highlight";
 
 type CaseStudy = Awaited<
   ReturnType<(typeof serverApi)["caseStudy"]["getInfiniteScroll"]>
@@ -14,6 +15,8 @@ type CaseStudy = Awaited<
 
 interface CaseStudyCardProps {
   caseStudy: CaseStudy;
+  /** The active search terms, marked wherever they appear. */
+  terms: string[];
 }
 
 const HOVER_ROTATION_SEEDS = [2, 3, 4, 5, -2, -3, -4, -5] as const;
@@ -26,7 +29,7 @@ function toTitleCase(value: string) {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
-export function CaseStudyCard({ caseStudy }: CaseStudyCardProps) {
+export function CaseStudyCard({ caseStudy, terms }: CaseStudyCardProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const coverRef = useRef<HTMLDivElement>(null);
@@ -193,7 +196,7 @@ export function CaseStudyCard({ caseStudy }: CaseStudyCardProps) {
                 key={type}
                 className="flex h-[22px] items-center rounded-full bg-foreground px-2 text-xs text-background"
               >
-                {toTitleCase(type)}
+                <Highlight text={toTitleCase(type)} terms={terms} />
               </span>
             ))}
           </div>
@@ -206,7 +209,7 @@ export function CaseStudyCard({ caseStudy }: CaseStudyCardProps) {
                 key={industry}
                 className="rounded-full bg-white px-2 py-0.5 text-xs font-medium text-neutral-700"
               >
-                {toTitleCase(industry)}
+                <Highlight text={toTitleCase(industry)} terms={terms} />
               </span>
             ))}
           </div>
@@ -214,16 +217,20 @@ export function CaseStudyCard({ caseStudy }: CaseStudyCardProps) {
       </div>
 
       <div className="mt-4 flex flex-col gap-1.5">
-        <h2 className="font-medium text-neutral-900">{caseStudy.name}</h2>
+        <h2 className="font-medium text-neutral-900">
+          <Highlight text={caseStudy.name} terms={terms} />
+        </h2>
 
         {caseStudy.aiSummary && (
           <p className="line-clamp-2 text-sm leading-snug text-neutral-600">
-            {caseStudy.aiSummary}
+            <Highlight text={caseStudy.aiSummary} terms={terms} />
           </p>
         )}
 
         {metadata.length > 0 && (
-          <p className="text-xs text-neutral-500">{metadata.join(" · ")}</p>
+          <p className="text-xs text-neutral-500">
+            <Highlight text={metadata.join(" · ")} terms={terms} />
+          </p>
         )}
       </div>
 

--- a/src/components/case-study-grid.tsx
+++ b/src/components/case-study-grid.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/hooks/params-parsers/use-case-study-filter-params";
 import { CaseStudyCard } from "./case-study-card";
 import BilliardBall from "./billiard-ball";
+import { parseSearchTerms } from "@/lib/search";
 
 interface CaseStudyGridProps {
   initialData: Awaited<
@@ -49,6 +50,15 @@ function CaseStudyGrid({ initialData, pageSize }: CaseStudyGridProps) {
     return infiniteCaseStudies.data?.pages.flatMap((page) => page.items);
   }, [infiniteCaseStudies.data]);
 
+  // Split the same way the router splits it, and taken from the committed URL
+  // rather than the search box's draft — the draft leads the URL by the
+  // debounce, so highlighting from it would mark a result set that hadn't been
+  // queried yet.
+  const searchTerms = useMemo(
+    () => parseSearchTerms(filterParams.q),
+    [filterParams.q],
+  );
+
   return (
     <>
       {infiniteCaseStudies.isLoading && (
@@ -81,7 +91,7 @@ function CaseStudyGrid({ initialData, pageSize }: CaseStudyGridProps) {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.5, delay: (i % pageSize) * 0.1 }}
               >
-                <CaseStudyCard caseStudy={item} />
+                <CaseStudyCard caseStudy={item} terms={searchTerms} />
               </motion.div>
             ))}
           </div>

--- a/src/components/case-study-grid.tsx
+++ b/src/components/case-study-grid.tsx
@@ -30,6 +30,7 @@ function CaseStudyGrid({ initialData, pageSize }: CaseStudyGridProps) {
       limit: pageSize,
       types: filterParams.types,
       industries: filterParams.industries,
+      q: filterParams.q,
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,
@@ -90,7 +91,11 @@ function CaseStudyGrid({ initialData, pageSize }: CaseStudyGridProps) {
       {!infiniteCaseStudies.isLoading && allItems?.length === 0 && (
         <div className="flex h-[calc(100vh-32rem)] flex-col items-center justify-center gap-4">
           <BilliardBall className="" ballType="8-ball" />
-          <p className="text-2xl">No projects yet</p>
+          {/* An empty table and a search that matched nothing are different
+              things to be told. */}
+          <p className="text-2xl">
+            {hasFilter ? "No results found" : "No projects yet"}
+          </p>
         </div>
       )}
     </>

--- a/src/components/collectable-card.tsx
+++ b/src/components/collectable-card.tsx
@@ -6,6 +6,7 @@ import { HelpCircle, MapPin } from "lucide-react";
 import { type api as serverApi } from "@/trpc/server";
 import { api } from "@/trpc/react";
 import { ImagePlaceholder } from "./image-placeholder";
+import { Highlight } from "./highlight";
 import { useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { badgeScaleForPointer, type CoverBox } from "@/lib/cursor-badge";
@@ -22,6 +23,13 @@ type Collectable = Awaited<
 
 interface CollectableCardProps {
   collectable: Collectable;
+  /**
+   * The active search terms, marked wherever they appear. Only the columns the
+   * router actually searches are marked — the location pill and the type badge
+   * are left alone, since a query never matches on either and highlighting
+   * them would claim a match that didn't happen.
+   */
+  terms: string[];
 }
 
 // A single blurred layer would start abruptly at whatever line it was masked
@@ -74,7 +82,7 @@ function buildDescriptionTint() {
   return `linear-gradient(to top, ${stops.join(", ")})`;
 }
 
-export function CollectableCard({ collectable }: CollectableCardProps) {
+export function CollectableCard({ collectable, terms }: CollectableCardProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const coverRef = useRef<HTMLDivElement>(null);
   const badgeRef = useRef<HTMLSpanElement>(null);
@@ -229,7 +237,7 @@ export function CollectableCard({ collectable }: CollectableCardProps) {
               back to starting at the top, which is where a reader expects to
               begin scrolling from. */}
           <p className="mt-auto px-5 pb-5 pt-8 text-sm leading-snug text-neutral-700">
-            {collectable.aiDescription}
+            <Highlight text={collectable.aiDescription} terms={terms} />
           </p>
         </div>
       </div>
@@ -292,12 +300,12 @@ export function CollectableCard({ collectable }: CollectableCardProps) {
           in the panel that slides up over the frame on hover. */}
       <div className="mt-3 flex flex-col items-center gap-1.5">
         <h2 className="text-center font-medium text-neutral-700">
-          {collectable.name}
+          <Highlight text={collectable.name} terms={terms} />
         </h2>
 
         {roleLine && (
           <p className="text-center text-sm leading-snug text-neutral-500">
-            {roleLine}
+            <Highlight text={roleLine} terms={terms} />
           </p>
         )}
 
@@ -312,7 +320,10 @@ export function CollectableCard({ collectable }: CollectableCardProps) {
                 key={tag}
                 className="rounded-full bg-neutral-100 px-2 py-0.5 text-xs font-medium text-neutral-600"
               >
-                {tag.charAt(0).toUpperCase() + tag.slice(1)}
+                <Highlight
+                  text={tag.charAt(0).toUpperCase() + tag.slice(1)}
+                  terms={terms}
+                />
               </span>
             ))}
           </div>

--- a/src/components/collectable-grid.tsx
+++ b/src/components/collectable-grid.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/hooks/params-parsers/use-collectable-filter-params";
 import { CollectableCard } from "./collectable-card";
 import BilliardBall from "./billiard-ball";
+import { parseSearchTerms } from "@/lib/search";
 interface CollectableGridProps {
   initialData: Awaited<
     ReturnType<(typeof serverApi)["collectable"]["getInfiniteScroll"]>
@@ -50,6 +51,15 @@ function CollectableGrid({ initialData, pageSize }: CollectableGridProps) {
     return infiniteCollectables.data?.pages.flatMap((page) => page.items);
   }, [infiniteCollectables.data]);
 
+  // Split the same way the router splits it, and taken from the committed URL
+  // rather than the search box's draft — the draft leads the URL by the
+  // debounce, so highlighting from it would mark a result set that hadn't been
+  // queried yet.
+  const searchTerms = useMemo(
+    () => parseSearchTerms(filterParams.q),
+    [filterParams.q],
+  );
+
   return (
     <>
       {infiniteCollectables.isLoading && (
@@ -80,7 +90,11 @@ function CollectableGrid({ initialData, pageSize }: CollectableGridProps) {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.5, delay: (i % pageSize) * 0.1 }}
               >
-                <CollectableCard key={item.id} collectable={item} />
+                <CollectableCard
+                  key={item.id}
+                  collectable={item}
+                  terms={searchTerms}
+                />
               </motion.div>
             ))}
           </div>

--- a/src/components/collectable-grid.tsx
+++ b/src/components/collectable-grid.tsx
@@ -30,6 +30,7 @@ function CollectableGrid({ initialData, pageSize }: CollectableGridProps) {
         limit: pageSize,
         type: filterParams.type,
         tags: filterParams.tags,
+        q: filterParams.q,
         sort: filterParams.sort,
       },
       {

--- a/src/components/highlight.tsx
+++ b/src/components/highlight.tsx
@@ -1,0 +1,44 @@
+import { splitOnMatches } from "@/lib/search";
+
+interface HighlightProps {
+  text: string;
+  terms: string[];
+}
+
+/**
+ * Marks the parts of a result that the query actually hit, so a card accounts
+ * for why it is in the grid rather than leaving the reader to guess which
+ * field matched.
+ *
+ * Only the matched characters are marked, inside a tag pill as much as in a
+ * name — searching "typo" blocks four letters of "Typography" rather than
+ * flipping the whole pill, which would overstate what matched.
+ *
+ * With no query this renders the bare string, so an unsearched grid produces
+ * the same DOM it did before highlighting existed.
+ */
+export function Highlight({ text, terms }: HighlightProps) {
+  const segments = splitOnMatches(text, terms);
+
+  if (segments.length === 1 && !segments[0]!.matched) return <>{text}</>;
+
+  return (
+    <>
+      {segments.map((segment, index) =>
+        segment.matched ? (
+          // `mark` is the element for this, but its user-agent yellow has to
+          // go: the highlight borrows the black-on-white pair the type and
+          // "Visit" badges already use, so it reads as part of the same set.
+          <mark
+            key={index}
+            className="rounded-[0.2em] bg-foreground px-[0.15em] text-background"
+          >
+            {segment.text}
+          </mark>
+        ) : (
+          <span key={index}>{segment.text}</span>
+        ),
+      )}
+    </>
+  );
+}

--- a/src/components/nav/case-study-filter.tsx
+++ b/src/components/nav/case-study-filter.tsx
@@ -6,8 +6,6 @@ import { useCaseStudyFilterParams } from "@/hooks/params-parsers/use-case-study-
 import { useMemo, useState } from "react";
 import { DropdownMenu } from "@/components/ui/dropdown-menu";
 import { motion } from "motion/react";
-import { SearchInput } from "./search-input";
-import { useDebouncedSearch } from "@/hooks/use-debounced-search";
 
 interface CaseStudyFilterProps {
   typeOptions: string[];
@@ -45,13 +43,8 @@ export function CaseStudyFilter({
   const [typeOpen, setTypeOpen] = useState(false);
   const [industryOpen, setIndustryOpen] = useState(false);
 
-  // Shallow, so the query re-runs the grid's client query without a server
-  // round trip for every keystroke.
-  const [searchDraft, setSearchDraft] = useDebouncedSearch(
-    search,
-    (q) => void setParams({ q }, { shallow: true }),
-  );
-
+  // The search box itself floats over the grid rather than sitting in this row,
+  // but reset is the one control that clears everything, search included.
   const hasAnySelection = useMemo(
     () =>
       selectedTypes.length > 0 ||
@@ -78,18 +71,12 @@ export function CaseStudyFilter({
         : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
     );
 
-  // An empty database means empty dropdowns — each one drops out on its own
-  // rather than render a control that can't do anything. Search stays either
-  // way; it has the same table to search whether or not the tags are filled in.
+  // An empty database means empty dropdowns — show nothing rather than
+  // controls that can't do anything.
+  if (typeOptions.length === 0 && industryOptions.length === 0) return null;
+
   return (
     <div className="flex items-center gap-2.5 pb-0 pt-0">
-      <SearchInput
-        value={searchDraft}
-        onValueChange={setSearchDraft}
-        placeholder="Search name, industry, keywords"
-        className="w-64"
-      />
-
       {typeOptions.length > 0 && (
         <DropdownMenu.Root open={typeOpen} onOpenChange={setTypeOpen}>
           <DropdownMenu.Trigger asChild>

--- a/src/components/nav/case-study-filter.tsx
+++ b/src/components/nav/case-study-filter.tsx
@@ -6,6 +6,8 @@ import { useCaseStudyFilterParams } from "@/hooks/params-parsers/use-case-study-
 import { useMemo, useState } from "react";
 import { DropdownMenu } from "@/components/ui/dropdown-menu";
 import { motion } from "motion/react";
+import { SearchInput } from "./search-input";
+import { useDebouncedSearch } from "@/hooks/use-debounced-search";
 
 interface CaseStudyFilterProps {
   typeOptions: string[];
@@ -34,14 +36,28 @@ export function CaseStudyFilter({
   industryOptions,
 }: CaseStudyFilterProps) {
   const [params, setParams] = useCaseStudyFilterParams();
-  const { types: selectedTypes, industries: selectedIndustries } = params;
+  const {
+    types: selectedTypes,
+    industries: selectedIndustries,
+    q: search,
+  } = params;
 
   const [typeOpen, setTypeOpen] = useState(false);
   const [industryOpen, setIndustryOpen] = useState(false);
 
+  // Shallow, so the query re-runs the grid's client query without a server
+  // round trip for every keystroke.
+  const [searchDraft, setSearchDraft] = useDebouncedSearch(
+    search,
+    (q) => void setParams({ q }, { shallow: true }),
+  );
+
   const hasAnySelection = useMemo(
-    () => selectedTypes.length > 0 || selectedIndustries.length > 0,
-    [selectedTypes, selectedIndustries],
+    () =>
+      selectedTypes.length > 0 ||
+      selectedIndustries.length > 0 ||
+      search !== "",
+    [selectedTypes, selectedIndustries, search],
   );
 
   const toggle = (key: "types" | "industries", value: string) => {
@@ -62,12 +78,18 @@ export function CaseStudyFilter({
         : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
     );
 
-  // An empty database means empty dropdowns — show nothing rather than
-  // controls that can't do anything.
-  if (typeOptions.length === 0 && industryOptions.length === 0) return null;
-
+  // An empty database means empty dropdowns — each one drops out on its own
+  // rather than render a control that can't do anything. Search stays either
+  // way; it has the same table to search whether or not the tags are filled in.
   return (
     <div className="flex items-center gap-2.5 pb-0 pt-0">
+      <SearchInput
+        value={searchDraft}
+        onValueChange={setSearchDraft}
+        placeholder="Search name, industry, keywords"
+        className="w-64"
+      />
+
       {typeOptions.length > 0 && (
         <DropdownMenu.Root open={typeOpen} onOpenChange={setTypeOpen}>
           <DropdownMenu.Trigger asChild>
@@ -144,7 +166,9 @@ export function CaseStudyFilter({
           column is narrow enough that the idle 36px matters. */}
       {hasAnySelection && (
         <button
-          onClick={() => setParams({ ...params, types: [], industries: [] })}
+          onClick={() =>
+            setParams({ ...params, types: [], industries: [], q: null })
+          }
           className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-neutral-200 text-neutral-900 transition-all hover:bg-neutral-300"
           aria-label="Reset filters"
         >

--- a/src/components/nav/desktop-nav.tsx
+++ b/src/components/nav/desktop-nav.tsx
@@ -5,6 +5,7 @@ import { Logo } from "./logo";
 import { useViewParams } from "@/hooks/params-parsers/use-view-params";
 import { ViewToggle } from "./view-toggle";
 import { CaseStudyFilter } from "./case-study-filter";
+import { FloatingSearch } from "./floating-search";
 
 interface DesktopNavProps {
   typeOptions: string[];
@@ -32,33 +33,37 @@ export function DesktopNav({
     );
 
   return (
-    <header
-      className="sticky top-0 z-40 hidden pb-6 pt-6 md:block"
-      style={{
-        backdropFilter: "blur(20px) brightness(1.1)",
-        WebkitBackdropFilter: "blur(20px) brightness(1.1)",
-        maskImage:
-          "linear-gradient(black 72%, rgba(0, 0, 0, 0.8) 85%, rgba(0, 0, 0, 0.6) 90%, rgba(0, 0, 0, 0.3) 95%, transparent)",
-        WebkitMaskImage:
-          "linear-gradient(black 72%, rgba(0, 0, 0, 0.8) 85%, rgba(0, 0, 0, 0.6) 90%, rgba(0, 0, 0, 0.3) 95%, transparent)",
-        background: "linear-gradient(white 72%, transparent)",
-      }}
-    >
-      {/* Same container as the grid below, so the first control lines up with
+    <>
+      <header
+        className="sticky top-0 z-40 hidden pb-6 pt-6 md:block"
+        style={{
+          backdropFilter: "blur(20px) brightness(1.1)",
+          WebkitBackdropFilter: "blur(20px) brightness(1.1)",
+          maskImage:
+            "linear-gradient(black 72%, rgba(0, 0, 0, 0.8) 85%, rgba(0, 0, 0, 0.6) 90%, rgba(0, 0, 0, 0.3) 95%, transparent)",
+          WebkitMaskImage:
+            "linear-gradient(black 72%, rgba(0, 0, 0, 0.8) 85%, rgba(0, 0, 0, 0.6) 90%, rgba(0, 0, 0, 0.3) 95%, transparent)",
+          background: "linear-gradient(white 72%, transparent)",
+        }}
+      >
+        {/* Same container as the grid below, so the first control lines up with
           the first card and the logo with the last one. */}
-      <div className="container mx-auto px-4 pb-6 md:px-6">
-        <div className="flex items-center justify-between gap-6">
-          {/* Every control lives in one left-aligned row. The blurb that used
+        <div className="container mx-auto px-4 pb-6 md:px-6">
+          <div className="flex items-center justify-between gap-6">
+            {/* Every control lives in one left-aligned row. The blurb that used
               to sit on the right is now the fixed footer, which is what frees
               up the width for however many controls a view needs. */}
-          <div className="flex flex-wrap items-center gap-2.5">
-            <ViewToggle />
-            {filters}
-          </div>
+            <div className="flex flex-wrap items-center gap-2.5">
+              <ViewToggle />
+              {filters}
+            </div>
 
-          <Logo align="right" className="h-12 w-[145px] flex-shrink-0" />
+            <Logo align="right" className="h-12 w-[145px] flex-shrink-0" />
+          </div>
         </div>
-      </div>
-    </header>
+      </header>
+
+      <FloatingSearch />
+    </>
   );
 }

--- a/src/components/nav/floating-search.tsx
+++ b/src/components/nav/floating-search.tsx
@@ -18,8 +18,18 @@ import { useViewParams } from "@/hooks/params-parsers/use-view-params";
  * Desktop only — the mobile sheet already holds every control at the bottom of
  * the screen, and a second floating bar would land on top of it.
  */
+
+/**
+ * The wash rises off the top of the bar and is gone by its bottom edge, so
+ * nothing is tinted below it.
+ *
+ * The stops have to reach zero just inside the box rather than at it: the box
+ * now ends level with the bar, and any alpha left at that line would show as a
+ * hard horizontal edge running out either side of the bar, which is worse than
+ * the tint being removed.
+ */
 const HALO =
-  "radial-gradient(60% 78% at 50% 78%, rgba(255,255,255,0.97) 0%, rgba(255,255,255,0.88) 45%, rgba(255,255,255,0) 72%)";
+  "radial-gradient(58% 45% at 50% 55%, rgba(255,255,255,0.97) 0%, rgba(255,255,255,0.9) 38%, rgba(255,255,255,0) 100%)";
 
 /**
  * Wide enough that the placeholder reads in full rather than clipping.
@@ -33,14 +43,16 @@ const BAR =
 
 function FloatingSearchShell({ children }: { children: React.ReactNode }) {
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 hidden justify-center md:flex">
-      {/* Bottom padding matches the footer links' own offset, so the bar and
-          the links share a line and end on the same edge. Centred on the
-          window, the bar still reaches the links below about 1024px even with
-          them trimmed to the two calls to action, so under `lg` it steps up
-          out of their way instead — narrowing it to fit would clip the
-          placeholder, which is the thing the width is there to prevent. */}
-      <div className="relative flex justify-center px-24 pb-16 pt-24 lg:pb-5">
+    // The bottom offset lives out here rather than on the box below, so that
+    // box — and the wash filling it — stops level with the bar instead of
+    // carrying on beneath it. It matches the footer links' own offset, so the
+    // bar and the links share a line and end on the same edge. Centred on the
+    // window, the bar still reaches the links below about 1024px even with
+    // them trimmed to the two calls to action, so under `lg` it steps up out
+    // of their way instead — narrowing it to fit would clip the placeholder,
+    // which is the thing the width is there to prevent.
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 hidden justify-center pb-16 md:flex lg:pb-5">
+      <div className="relative flex justify-center px-24 pt-24">
         <div
           aria-hidden
           className="absolute inset-0"

--- a/src/components/nav/floating-search.tsx
+++ b/src/components/nav/floating-search.tsx
@@ -11,55 +11,34 @@ import { useViewParams } from "@/hooks/params-parsers/use-view-params";
  *
  * It sits apart from the filter row on purpose: search is the one control you
  * reach for while reading the cards, so it stays within thumb's reach of where
- * you are rather than back up at the top of the page. Cards scroll underneath,
- * and the radial wash behind it fades them out just enough to keep the bar
- * legible without reading as a solid bar pinned across the window.
+ * you are rather than back up at the top of the page. Cards scroll underneath
+ * it untouched — nothing is painted behind the bar, so its own fill and the
+ * shadow under it are what hold it apart from whatever it passes over.
  *
  * Desktop only — the mobile sheet already holds every control at the bottom of
  * the screen, and a second floating bar would land on top of it.
  */
 
 /**
- * The wash rises off the top of the bar and is gone by its bottom edge, so
- * nothing is tinted below it.
- *
- * The stops have to reach zero just inside the box rather than at it: the box
- * now ends level with the bar, and any alpha left at that line would show as a
- * hard horizontal edge running out either side of the bar, which is worse than
- * the tint being removed.
- */
-const HALO =
-  "radial-gradient(58% 45% at 50% 55%, rgba(255,255,255,0.97) 0%, rgba(255,255,255,0.9) 38%, rgba(255,255,255,0) 100%)";
-
-/**
  * Wide enough that the placeholder reads in full rather than clipping.
  *
  * A step lighter than the filter chips it echoes: those sit on the header's
- * flat white, while this one sits on the wash with a shadow under it, and the
- * chips' own neutral-200 reads heavy against that.
+ * flat white, while this one sits over the grid with a shadow under it, and
+ * the chips' own neutral-200 reads heavy there.
  */
 const BAR =
   "w-[26rem] bg-neutral-100 hover:bg-neutral-200 focus-within:bg-neutral-200 shadow-[0_4px_16px_-6px_rgba(0,0,0,0.18)]";
 
 function FloatingSearchShell({ children }: { children: React.ReactNode }) {
   return (
-    // The bottom offset lives out here rather than on the box below, so that
-    // box — and the wash filling it — stops level with the bar instead of
-    // carrying on beneath it. It matches the footer links' own offset, so the
-    // bar and the links share a line and end on the same edge. Centred on the
-    // window, the bar still reaches the links below about 1024px even with
-    // them trimmed to the two calls to action, so under `lg` it steps up out
-    // of their way instead — narrowing it to fit would clip the placeholder,
-    // which is the thing the width is there to prevent.
+    // The bottom offset matches the footer links' own, so the bar and the
+    // links share a line and end on the same edge. Centred on the window, the
+    // bar still reaches the links below about 1024px even with them trimmed to
+    // the two calls to action, so under `lg` it steps up out of their way
+    // instead — narrowing it to fit would clip the placeholder, which is the
+    // thing the width is there to prevent.
     <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 hidden justify-center pb-16 md:flex lg:pb-5">
-      <div className="relative flex justify-center px-24 pt-24">
-        <div
-          aria-hidden
-          className="absolute inset-0"
-          style={{ background: HALO }}
-        />
-        {children}
-      </div>
+      {children}
     </div>
   );
 }
@@ -78,7 +57,7 @@ function DesignerSearch() {
     <SearchInput
       value={searchDraft}
       onValueChange={setSearchDraft}
-      className={`pointer-events-auto relative ${BAR}`}
+      className={`pointer-events-auto ${BAR}`}
     />
   );
 }
@@ -96,7 +75,7 @@ function ProjectSearch() {
       value={searchDraft}
       onValueChange={setSearchDraft}
       placeholder="Search name, industry, keywords"
-      className={`pointer-events-auto relative ${BAR}`}
+      className={`pointer-events-auto ${BAR}`}
     />
   );
 }

--- a/src/components/nav/floating-search.tsx
+++ b/src/components/nav/floating-search.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { SearchInput } from "./search-input";
+import { useDebouncedSearch } from "@/hooks/use-debounced-search";
+import { useCollectableFilterParams } from "@/hooks/params-parsers/use-collectable-filter-params";
+import { useCaseStudyFilterParams } from "@/hooks/params-parsers/use-case-study-filter-params";
+import { useViewParams } from "@/hooks/params-parsers/use-view-params";
+
+/**
+ * The search box, floating over the bottom of the grid.
+ *
+ * It sits apart from the filter row on purpose: search is the one control you
+ * reach for while reading the cards, so it stays within thumb's reach of where
+ * you are rather than back up at the top of the page. Cards scroll underneath,
+ * and the radial wash behind it fades them out just enough to keep the bar
+ * legible without reading as a solid bar pinned across the window.
+ *
+ * Desktop only — the mobile sheet already holds every control at the bottom of
+ * the screen, and a second floating bar would land on top of it.
+ */
+const HALO =
+  "radial-gradient(60% 78% at 50% 78%, rgba(255,255,255,0.97) 0%, rgba(255,255,255,0.88) 45%, rgba(255,255,255,0) 72%)";
+
+/** Wide enough that the placeholder reads in full rather than clipping. */
+const BAR_WIDTH = "w-[26rem]";
+
+function FloatingSearchShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 hidden justify-center md:flex">
+      {/* The bottom padding is what keeps the bar out of the footer blurb's
+          band. Centred on the window, the bar reaches past the blurb's left
+          edge on anything narrower than about 1280px, so it clears it
+          vertically instead — at every width, rather than only where the
+          collision happens, so the bar doesn't jump on resize. */}
+      <div className="relative flex justify-center px-24 pb-24 pt-24">
+        <div
+          aria-hidden
+          className="absolute inset-0"
+          style={{ background: HALO }}
+        />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function DesignerSearch() {
+  const [params, setParams] = useCollectableFilterParams();
+
+  // Shallow, so the query re-runs the grid's client query without a server
+  // round trip for every keystroke.
+  const [searchDraft, setSearchDraft] = useDebouncedSearch(
+    params.q,
+    (q) => void setParams({ q }, { shallow: true }),
+  );
+
+  return (
+    <SearchInput
+      value={searchDraft}
+      onValueChange={setSearchDraft}
+      className={`pointer-events-auto relative ${BAR_WIDTH} shadow-lg shadow-neutral-900/10`}
+    />
+  );
+}
+
+function ProjectSearch() {
+  const [params, setParams] = useCaseStudyFilterParams();
+
+  const [searchDraft, setSearchDraft] = useDebouncedSearch(
+    params.q,
+    (q) => void setParams({ q }, { shallow: true }),
+  );
+
+  return (
+    <SearchInput
+      value={searchDraft}
+      onValueChange={setSearchDraft}
+      placeholder="Search name, industry, keywords"
+      className={`pointer-events-auto relative ${BAR_WIDTH} shadow-lg shadow-neutral-900/10`}
+    />
+  );
+}
+
+export function FloatingSearch() {
+  const [{ view }] = useViewParams();
+
+  return (
+    <FloatingSearchShell>
+      {view === "case-study" ? <ProjectSearch /> : <DesignerSearch />}
+    </FloatingSearchShell>
+  );
+}

--- a/src/components/nav/floating-search.tsx
+++ b/src/components/nav/floating-search.tsx
@@ -21,18 +21,26 @@ import { useViewParams } from "@/hooks/params-parsers/use-view-params";
 const HALO =
   "radial-gradient(60% 78% at 50% 78%, rgba(255,255,255,0.97) 0%, rgba(255,255,255,0.88) 45%, rgba(255,255,255,0) 72%)";
 
-/** Wide enough that the placeholder reads in full rather than clipping. */
-const BAR_WIDTH = "w-[26rem]";
+/**
+ * Wide enough that the placeholder reads in full rather than clipping.
+ *
+ * A step lighter than the filter chips it echoes: those sit on the header's
+ * flat white, while this one sits on the wash with a shadow under it, and the
+ * chips' own neutral-200 reads heavy against that.
+ */
+const BAR =
+  "w-[26rem] bg-neutral-100 hover:bg-neutral-200 focus-within:bg-neutral-200 shadow-[0_4px_16px_-6px_rgba(0,0,0,0.18)]";
 
 function FloatingSearchShell({ children }: { children: React.ReactNode }) {
   return (
     <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 hidden justify-center md:flex">
-      {/* The bottom padding is what keeps the bar out of the footer blurb's
-          band. Centred on the window, the bar reaches past the blurb's left
-          edge on anything narrower than about 1280px, so it clears it
-          vertically instead — at every width, rather than only where the
-          collision happens, so the bar doesn't jump on resize. */}
-      <div className="relative flex justify-center px-24 pb-24 pt-24">
+      {/* Bottom padding matches the footer links' own offset, so the bar and
+          the links share a line and end on the same edge. Centred on the
+          window, the bar still reaches the links below about 1024px even with
+          them trimmed to the two calls to action, so under `lg` it steps up
+          out of their way instead — narrowing it to fit would clip the
+          placeholder, which is the thing the width is there to prevent. */}
+      <div className="relative flex justify-center px-24 pb-16 pt-24 lg:pb-5">
         <div
           aria-hidden
           className="absolute inset-0"
@@ -58,7 +66,7 @@ function DesignerSearch() {
     <SearchInput
       value={searchDraft}
       onValueChange={setSearchDraft}
-      className={`pointer-events-auto relative ${BAR_WIDTH} shadow-lg shadow-neutral-900/10`}
+      className={`pointer-events-auto relative ${BAR}`}
     />
   );
 }
@@ -76,7 +84,7 @@ function ProjectSearch() {
       value={searchDraft}
       onValueChange={setSearchDraft}
       placeholder="Search name, industry, keywords"
-      className={`pointer-events-auto relative ${BAR_WIDTH} shadow-lg shadow-neutral-900/10`}
+      className={`pointer-events-auto relative ${BAR}`}
     />
   );
 }

--- a/src/components/nav/floating-search.tsx
+++ b/src/components/nav/floating-search.tsx
@@ -22,12 +22,11 @@ import { useViewParams } from "@/hooks/params-parsers/use-view-params";
 /**
  * Wide enough that the placeholder reads in full rather than clipping.
  *
- * A step lighter than the filter chips it echoes: those sit on the header's
- * flat white, while this one sits over the grid with a shadow under it, and
- * the chips' own neutral-200 reads heavy there.
+ * Width and lift are all this adds. The grey is the one `SearchInput` already
+ * carries, which is the filter chips' grey too — so the bar reads as the same
+ * family of control, and the shadow alone is what sets it above the page.
  */
-const BAR =
-  "w-[26rem] bg-neutral-100 hover:bg-neutral-200 focus-within:bg-neutral-200 shadow-[0_4px_16px_-6px_rgba(0,0,0,0.18)]";
+const BAR = "w-[26rem] shadow-float";
 
 function FloatingSearchShell({ children }: { children: React.ReactNode }) {
   return (

--- a/src/components/nav/horizontal-filter.tsx
+++ b/src/components/nav/horizontal-filter.tsx
@@ -8,8 +8,6 @@ import { DropdownMenu } from "@/components/ui/dropdown-menu";
 import { CaretDown } from "@phosphor-icons/react";
 import { motion } from "motion/react";
 import { DEFAULT_SORT, SORT_OPTIONS, getSortLabel } from "@/lib/sort-options";
-import { SearchInput } from "./search-input";
-import { useDebouncedSearch } from "@/hooks/use-debounced-search";
 
 interface HorizontalFilterProps {
   tagOptions: string[];
@@ -28,13 +26,8 @@ export function HorizontalFilter({
     q: search,
   } = params;
 
-  // Shallow, so the query re-runs the grid's client query without a server
-  // round trip for every keystroke.
-  const [searchDraft, setSearchDraft] = useDebouncedSearch(
-    search,
-    (q) => void setParams({ q }, { shallow: true }),
-  );
-
+  // The search box itself floats over the grid rather than sitting in this row,
+  // but reset is the one control that clears everything, search included.
   const hasAnySelection = useMemo(() => {
     return (
       selectedType ||
@@ -72,147 +65,132 @@ export function HorizontalFilter({
   const [tagOpen, setTagOpen] = useState(false);
   const [sortOpen, setSortOpen] = useState(false);
 
-  // Nothing to filter by — the dropdowns drop out rather than render controls
-  // that can't do anything, but search still has a table to search.
-  const hasFilterOptions = typeOptions.length > 0 || tagOptions.length > 0;
+  // Nothing to filter by — don't render controls that can't do anything.
+  if (typeOptions.length === 0 && tagOptions.length === 0) return null;
 
   return (
     <div className="flex items-center gap-2.5 pb-0 pt-0">
-      <SearchInput
-        value={searchDraft}
-        onValueChange={setSearchDraft}
-        className="w-64"
-      />
+      {/* Type Dropdown */}
+      <DropdownMenu.Root open={typeOpen} onOpenChange={setTypeOpen}>
+        <DropdownMenu.Trigger asChild>
+          <button
+            className={cn(
+              "flex h-9 items-center gap-2 rounded-full px-4 text-base font-normal transition-colors focus:outline-none",
+              typeOpen
+                ? "bg-black text-white"
+                : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
+            )}
+          >
+            {selectedTypeLabel}
+            <motion.div
+              animate={{ rotate: typeOpen ? 180 : 0 }}
+              transition={{ duration: 0.2, ease: "easeInOut" }}
+            >
+              <CaretDown weight="fill" className="h-5 w-5" />
+            </motion.div>
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content open={typeOpen}>
+          {typeOptions.map((type) => (
+            <DropdownMenu.Item
+              key={type}
+              onSelect={() =>
+                void setParams({
+                  ...params,
+                  type: selectedType === type ? null : type,
+                })
+              }
+              selected={selectedType === type}
+            >
+              {toTitleCase(type)}
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
 
-      {hasFilterOptions && (
-        <>
-          {/* Type Dropdown */}
-          <DropdownMenu.Root open={typeOpen} onOpenChange={setTypeOpen}>
-            <DropdownMenu.Trigger asChild>
-              <button
-                className={cn(
-                  "flex h-9 items-center gap-2 rounded-full px-4 text-base font-normal transition-colors focus:outline-none",
-                  typeOpen
-                    ? "bg-black text-white"
-                    : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
-                )}
-              >
-                {selectedTypeLabel}
-                <motion.div
-                  animate={{ rotate: typeOpen ? 180 : 0 }}
-                  transition={{ duration: 0.2, ease: "easeInOut" }}
-                >
-                  <CaretDown weight="fill" className="h-5 w-5" />
-                </motion.div>
-              </button>
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content open={typeOpen}>
-              {typeOptions.map((type) => (
-                <DropdownMenu.Item
-                  key={type}
-                  onSelect={() =>
+      {/* Tag Dropdown (multi-select) */}
+      <DropdownMenu.Root open={tagOpen} onOpenChange={setTagOpen}>
+        <DropdownMenu.Trigger asChild>
+          <button
+            className={cn(
+              "flex h-9 items-center gap-2 rounded-full px-4 text-base font-normal transition-colors focus:outline-none",
+              tagOpen
+                ? "bg-black text-white"
+                : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
+            )}
+            style={{ maxWidth: 240 }}
+          >
+            <span className="max-w-[240px] truncate">{selectedTagsLabel}</span>
+            <motion.div
+              animate={{ rotate: tagOpen ? 180 : 0 }}
+              transition={{ duration: 0.2, ease: "easeInOut" }}
+              className="flex-shrink-0"
+            >
+              <CaretDown weight="fill" className="h-5 w-5" />
+            </motion.div>
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content open={tagOpen}>
+          {tagOptions.map((tag) => {
+            const isSelected = selectedTags?.includes(tag);
+            return (
+              <DropdownMenu.Item
+                key={tag}
+                onSelect={(e) => {
+                  e.preventDefault(); // Prevent menu from closing
+                  if (isSelected) {
                     void setParams({
                       ...params,
-                      type: selectedType === type ? null : type,
-                    })
+                      tags: selectedTags.filter((t) => t !== tag),
+                    });
+                  } else {
+                    void setParams({
+                      ...params,
+                      tags: [...(selectedTags || []), tag],
+                    });
                   }
-                  selected={selectedType === type}
-                >
-                  {toTitleCase(type)}
-                </DropdownMenu.Item>
-              ))}
-            </DropdownMenu.Content>
-          </DropdownMenu.Root>
-
-          {/* Tag Dropdown (multi-select) */}
-          <DropdownMenu.Root open={tagOpen} onOpenChange={setTagOpen}>
-            <DropdownMenu.Trigger asChild>
-              <button
-                className={cn(
-                  "flex h-9 items-center gap-2 rounded-full px-4 text-base font-normal transition-colors focus:outline-none",
-                  tagOpen
-                    ? "bg-black text-white"
-                    : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
-                )}
-                style={{ maxWidth: 240 }}
+                }}
+                selected={isSelected}
               >
-                <span className="max-w-[240px] truncate">
-                  {selectedTagsLabel}
-                </span>
-                <motion.div
-                  animate={{ rotate: tagOpen ? 180 : 0 }}
-                  transition={{ duration: 0.2, ease: "easeInOut" }}
-                  className="flex-shrink-0"
-                >
-                  <CaretDown weight="fill" className="h-5 w-5" />
-                </motion.div>
-              </button>
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content open={tagOpen}>
-              {tagOptions.map((tag) => {
-                const isSelected = selectedTags?.includes(tag);
-                return (
-                  <DropdownMenu.Item
-                    key={tag}
-                    onSelect={(e) => {
-                      e.preventDefault(); // Prevent menu from closing
-                      if (isSelected) {
-                        void setParams({
-                          ...params,
-                          tags: selectedTags.filter((t) => t !== tag),
-                        });
-                      } else {
-                        void setParams({
-                          ...params,
-                          tags: [...(selectedTags || []), tag],
-                        });
-                      }
-                    }}
-                    selected={isSelected}
-                  >
-                    {toTitleCase(tag)}
-                  </DropdownMenu.Item>
-                );
-              })}
-            </DropdownMenu.Content>
-          </DropdownMenu.Root>
+                {toTitleCase(tag)}
+              </DropdownMenu.Item>
+            );
+          })}
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
 
-          {/* Sort Dropdown */}
-          <DropdownMenu.Root open={sortOpen} onOpenChange={setSortOpen}>
-            <DropdownMenu.Trigger asChild>
-              <button
-                className={cn(
-                  "flex h-9 items-center gap-2 rounded-full px-4 text-base font-normal transition-colors focus:outline-none",
-                  sortOpen
-                    ? "bg-black text-white"
-                    : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
-                )}
-              >
-                {getSortLabel(selectedSort)}
-                <motion.div
-                  animate={{ rotate: sortOpen ? 180 : 0 }}
-                  transition={{ duration: 0.2, ease: "easeInOut" }}
-                >
-                  <CaretDown weight="fill" className="h-5 w-5" />
-                </motion.div>
-              </button>
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content open={sortOpen}>
-              {SORT_OPTIONS.map((option) => (
-                <DropdownMenu.Item
-                  key={option.value}
-                  onSelect={() =>
-                    void setParams({ ...params, sort: option.value })
-                  }
-                  selected={selectedSort === option.value}
-                >
-                  {option.label}
-                </DropdownMenu.Item>
-              ))}
-            </DropdownMenu.Content>
-          </DropdownMenu.Root>
-        </>
-      )}
+      {/* Sort Dropdown */}
+      <DropdownMenu.Root open={sortOpen} onOpenChange={setSortOpen}>
+        <DropdownMenu.Trigger asChild>
+          <button
+            className={cn(
+              "flex h-9 items-center gap-2 rounded-full px-4 text-base font-normal transition-colors focus:outline-none",
+              sortOpen
+                ? "bg-black text-white"
+                : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
+            )}
+          >
+            {getSortLabel(selectedSort)}
+            <motion.div
+              animate={{ rotate: sortOpen ? 180 : 0 }}
+              transition={{ duration: 0.2, ease: "easeInOut" }}
+            >
+              <CaretDown weight="fill" className="h-5 w-5" />
+            </motion.div>
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content open={sortOpen}>
+          {SORT_OPTIONS.map((option) => (
+            <DropdownMenu.Item
+              key={option.value}
+              onSelect={() => void setParams({ ...params, sort: option.value })}
+              selected={selectedSort === option.value}
+            >
+              {option.label}
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
 
       {/* Reset button — only occupies space once a filter is applied. */}
       {hasAnySelection && (

--- a/src/components/nav/horizontal-filter.tsx
+++ b/src/components/nav/horizontal-filter.tsx
@@ -7,11 +7,9 @@ import { useMemo, useState } from "react";
 import { DropdownMenu } from "@/components/ui/dropdown-menu";
 import { CaretDown } from "@phosphor-icons/react";
 import { motion } from "motion/react";
-import {
-  DEFAULT_SORT,
-  SORT_OPTIONS,
-  getSortLabel,
-} from "@/lib/sort-options";
+import { DEFAULT_SORT, SORT_OPTIONS, getSortLabel } from "@/lib/sort-options";
+import { SearchInput } from "./search-input";
+import { useDebouncedSearch } from "@/hooks/use-debounced-search";
 
 interface HorizontalFilterProps {
   tagOptions: string[];
@@ -23,15 +21,28 @@ export function HorizontalFilter({
   typeOptions,
 }: HorizontalFilterProps) {
   const [params, setParams] = useCollectableFilterParams();
-  const { type: selectedType, tags: selectedTags, sort: selectedSort } = params;
+  const {
+    type: selectedType,
+    tags: selectedTags,
+    sort: selectedSort,
+    q: search,
+  } = params;
+
+  // Shallow, so the query re-runs the grid's client query without a server
+  // round trip for every keystroke.
+  const [searchDraft, setSearchDraft] = useDebouncedSearch(
+    search,
+    (q) => void setParams({ q }, { shallow: true }),
+  );
 
   const hasAnySelection = useMemo(() => {
     return (
       selectedType ||
       (selectedTags && selectedTags.length > 0) ||
+      search !== "" ||
       selectedSort !== DEFAULT_SORT
     );
-  }, [selectedType, selectedTags, selectedSort]);
+  }, [selectedType, selectedTags, search, selectedSort]);
 
   // Helper for showing selected tags as comma-separated
   function toTitleCase(str: string) {
@@ -61,138 +72,159 @@ export function HorizontalFilter({
   const [tagOpen, setTagOpen] = useState(false);
   const [sortOpen, setSortOpen] = useState(false);
 
-  // Nothing to filter by — don't render controls that can't do anything.
-  if (typeOptions.length === 0 && tagOptions.length === 0) return null;
+  // Nothing to filter by — the dropdowns drop out rather than render controls
+  // that can't do anything, but search still has a table to search.
+  const hasFilterOptions = typeOptions.length > 0 || tagOptions.length > 0;
 
   return (
     <div className="flex items-center gap-2.5 pb-0 pt-0">
-      {/* Type Dropdown */}
-      <DropdownMenu.Root open={typeOpen} onOpenChange={setTypeOpen}>
-        <DropdownMenu.Trigger asChild>
-          <button
-            className={cn(
-              "flex h-9 items-center gap-2 rounded-full px-4 text-base font-normal transition-colors focus:outline-none",
-              typeOpen
-                ? "bg-black text-white"
-                : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
-            )}
-          >
-            {selectedTypeLabel}
-            <motion.div
-              animate={{ rotate: typeOpen ? 180 : 0 }}
-              transition={{ duration: 0.2, ease: "easeInOut" }}
-            >
-              <CaretDown weight="fill" className="h-5 w-5" />
-            </motion.div>
-          </button>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Content open={typeOpen}>
-          {typeOptions.map((type) => (
-            <DropdownMenu.Item
-              key={type}
-              onSelect={() =>
-                void setParams({
-                  ...params,
-                  type: selectedType === type ? null : type,
-                })
-              }
-              selected={selectedType === type}
-            >
-              {toTitleCase(type)}
-            </DropdownMenu.Item>
-          ))}
-        </DropdownMenu.Content>
-      </DropdownMenu.Root>
+      <SearchInput
+        value={searchDraft}
+        onValueChange={setSearchDraft}
+        className="w-64"
+      />
 
-      {/* Tag Dropdown (multi-select) */}
-      <DropdownMenu.Root open={tagOpen} onOpenChange={setTagOpen}>
-        <DropdownMenu.Trigger asChild>
-          <button
-            className={cn(
-              "flex h-9 items-center gap-2 rounded-full px-4 text-base font-normal transition-colors focus:outline-none",
-              tagOpen
-                ? "bg-black text-white"
-                : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
-            )}
-            style={{ maxWidth: 240 }}
-          >
-            <span className="max-w-[240px] truncate">{selectedTagsLabel}</span>
-            <motion.div
-              animate={{ rotate: tagOpen ? 180 : 0 }}
-              transition={{ duration: 0.2, ease: "easeInOut" }}
-              className="flex-shrink-0"
-            >
-              <CaretDown weight="fill" className="h-5 w-5" />
-            </motion.div>
-          </button>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Content open={tagOpen}>
-          {tagOptions.map((tag) => {
-            const isSelected = selectedTags?.includes(tag);
-            return (
-              <DropdownMenu.Item
-                key={tag}
-                onSelect={(e) => {
-                  e.preventDefault(); // Prevent menu from closing
-                  if (isSelected) {
-                    void setParams({
-                      ...params,
-                      tags: selectedTags.filter((t) => t !== tag),
-                    });
-                  } else {
-                    void setParams({
-                      ...params,
-                      tags: [...(selectedTags || []), tag],
-                    });
-                  }
-                }}
-                selected={isSelected}
+      {hasFilterOptions && (
+        <>
+          {/* Type Dropdown */}
+          <DropdownMenu.Root open={typeOpen} onOpenChange={setTypeOpen}>
+            <DropdownMenu.Trigger asChild>
+              <button
+                className={cn(
+                  "flex h-9 items-center gap-2 rounded-full px-4 text-base font-normal transition-colors focus:outline-none",
+                  typeOpen
+                    ? "bg-black text-white"
+                    : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
+                )}
               >
-                {toTitleCase(tag)}
-              </DropdownMenu.Item>
-            );
-          })}
-        </DropdownMenu.Content>
-      </DropdownMenu.Root>
+                {selectedTypeLabel}
+                <motion.div
+                  animate={{ rotate: typeOpen ? 180 : 0 }}
+                  transition={{ duration: 0.2, ease: "easeInOut" }}
+                >
+                  <CaretDown weight="fill" className="h-5 w-5" />
+                </motion.div>
+              </button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content open={typeOpen}>
+              {typeOptions.map((type) => (
+                <DropdownMenu.Item
+                  key={type}
+                  onSelect={() =>
+                    void setParams({
+                      ...params,
+                      type: selectedType === type ? null : type,
+                    })
+                  }
+                  selected={selectedType === type}
+                >
+                  {toTitleCase(type)}
+                </DropdownMenu.Item>
+              ))}
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
 
-      {/* Sort Dropdown */}
-      <DropdownMenu.Root open={sortOpen} onOpenChange={setSortOpen}>
-        <DropdownMenu.Trigger asChild>
-          <button
-            className={cn(
-              "flex h-9 items-center gap-2 rounded-full px-4 text-base font-normal transition-colors focus:outline-none",
-              sortOpen
-                ? "bg-black text-white"
-                : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300"
-            )}
-          >
-            {getSortLabel(selectedSort)}
-            <motion.div
-              animate={{ rotate: sortOpen ? 180 : 0 }}
-              transition={{ duration: 0.2, ease: "easeInOut" }}
-            >
-              <CaretDown weight="fill" className="h-5 w-5" />
-            </motion.div>
-          </button>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Content open={sortOpen}>
-          {SORT_OPTIONS.map((option) => (
-            <DropdownMenu.Item
-              key={option.value}
-              onSelect={() => void setParams({ ...params, sort: option.value })}
-              selected={selectedSort === option.value}
-            >
-              {option.label}
-            </DropdownMenu.Item>
-          ))}
-        </DropdownMenu.Content>
-      </DropdownMenu.Root>
+          {/* Tag Dropdown (multi-select) */}
+          <DropdownMenu.Root open={tagOpen} onOpenChange={setTagOpen}>
+            <DropdownMenu.Trigger asChild>
+              <button
+                className={cn(
+                  "flex h-9 items-center gap-2 rounded-full px-4 text-base font-normal transition-colors focus:outline-none",
+                  tagOpen
+                    ? "bg-black text-white"
+                    : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
+                )}
+                style={{ maxWidth: 240 }}
+              >
+                <span className="max-w-[240px] truncate">
+                  {selectedTagsLabel}
+                </span>
+                <motion.div
+                  animate={{ rotate: tagOpen ? 180 : 0 }}
+                  transition={{ duration: 0.2, ease: "easeInOut" }}
+                  className="flex-shrink-0"
+                >
+                  <CaretDown weight="fill" className="h-5 w-5" />
+                </motion.div>
+              </button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content open={tagOpen}>
+              {tagOptions.map((tag) => {
+                const isSelected = selectedTags?.includes(tag);
+                return (
+                  <DropdownMenu.Item
+                    key={tag}
+                    onSelect={(e) => {
+                      e.preventDefault(); // Prevent menu from closing
+                      if (isSelected) {
+                        void setParams({
+                          ...params,
+                          tags: selectedTags.filter((t) => t !== tag),
+                        });
+                      } else {
+                        void setParams({
+                          ...params,
+                          tags: [...(selectedTags || []), tag],
+                        });
+                      }
+                    }}
+                    selected={isSelected}
+                  >
+                    {toTitleCase(tag)}
+                  </DropdownMenu.Item>
+                );
+              })}
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+
+          {/* Sort Dropdown */}
+          <DropdownMenu.Root open={sortOpen} onOpenChange={setSortOpen}>
+            <DropdownMenu.Trigger asChild>
+              <button
+                className={cn(
+                  "flex h-9 items-center gap-2 rounded-full px-4 text-base font-normal transition-colors focus:outline-none",
+                  sortOpen
+                    ? "bg-black text-white"
+                    : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
+                )}
+              >
+                {getSortLabel(selectedSort)}
+                <motion.div
+                  animate={{ rotate: sortOpen ? 180 : 0 }}
+                  transition={{ duration: 0.2, ease: "easeInOut" }}
+                >
+                  <CaretDown weight="fill" className="h-5 w-5" />
+                </motion.div>
+              </button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content open={sortOpen}>
+              {SORT_OPTIONS.map((option) => (
+                <DropdownMenu.Item
+                  key={option.value}
+                  onSelect={() =>
+                    void setParams({ ...params, sort: option.value })
+                  }
+                  selected={selectedSort === option.value}
+                >
+                  {option.label}
+                </DropdownMenu.Item>
+              ))}
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+        </>
+      )}
 
       {/* Reset button — only occupies space once a filter is applied. */}
       {hasAnySelection && (
         <button
           onClick={() =>
-            setParams({ ...params, type: null, tags: [], sort: DEFAULT_SORT })
+            setParams({
+              ...params,
+              type: null,
+              tags: [],
+              q: null,
+              sort: DEFAULT_SORT,
+            })
           }
           className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-neutral-200 text-neutral-900 transition-all hover:bg-neutral-300"
           aria-label="Reset filters"

--- a/src/components/nav/mobile-case-study-filter.tsx
+++ b/src/components/nav/mobile-case-study-filter.tsx
@@ -6,6 +6,8 @@ import { motion } from "motion/react";
 import { cn } from "@/lib/utils";
 import { MobileDropdown } from "@/components/ui/mobile-dropdown";
 import { useCaseStudyFilterParams } from "@/hooks/params-parsers/use-case-study-filter-params";
+import { SearchInput } from "./search-input";
+import { useDebouncedSearch } from "@/hooks/use-debounced-search";
 
 interface MobileCaseStudyFilterProps {
   typeOptions: string[];
@@ -31,14 +33,28 @@ export function MobileCaseStudyFilter({
   industryOptions,
 }: MobileCaseStudyFilterProps) {
   const [params, setParams] = useCaseStudyFilterParams();
-  const { types: selectedTypes, industries: selectedIndustries } = params;
+  const {
+    types: selectedTypes,
+    industries: selectedIndustries,
+    q: search,
+  } = params;
 
   const [typeOpen, setTypeOpen] = useState(false);
   const [industryOpen, setIndustryOpen] = useState(false);
 
+  // Shallow, so the query re-runs the grid's client query without a server
+  // round trip for every keystroke.
+  const [searchDraft, setSearchDraft] = useDebouncedSearch(
+    search,
+    (q) => void setParams({ q }, { shallow: true }),
+  );
+
   const hasAnySelection = useMemo(
-    () => selectedTypes.length > 0 || selectedIndustries.length > 0,
-    [selectedTypes, selectedIndustries],
+    () =>
+      selectedTypes.length > 0 ||
+      selectedIndustries.length > 0 ||
+      search !== "",
+    [selectedTypes, selectedIndustries, search],
   );
 
   const toggle = (key: "types" | "industries", value: string) => {
@@ -60,11 +76,17 @@ export function MobileCaseStudyFilter({
     );
 
   // No options means no filters to show — the sheet still carries the view
-  // toggle and Info, so only these controls drop out.
-  if (typeOptions.length === 0 && industryOptions.length === 0) return null;
-
+  // toggle and Info, so only those controls drop out. Search stays either way;
+  // it has the same table to search whether or not the tags are filled in.
   return (
     <>
+      <SearchInput
+        value={searchDraft}
+        onValueChange={setSearchDraft}
+        placeholder="Search name, industry, keywords"
+        className="h-auto w-full px-5 py-3"
+      />
+
       {typeOptions.length > 0 && (
         <button
           onClick={() => setTypeOpen(true)}
@@ -103,7 +125,9 @@ export function MobileCaseStudyFilter({
 
       {hasAnySelection && (
         <button
-          onClick={() => setParams({ ...params, types: [], industries: [] })}
+          onClick={() =>
+            setParams({ ...params, types: [], industries: [], q: null })
+          }
           className="flex w-full items-center justify-between gap-2 rounded-full bg-neutral-200 px-5 py-3 text-base font-normal text-neutral-900 transition-colors hover:bg-neutral-300"
           aria-label="Reset filters"
         >

--- a/src/components/nav/mobile-nav.tsx
+++ b/src/components/nav/mobile-nav.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { ArrowCounterClockwise, CaretDown, CaretUp } from "@phosphor-icons/react";
+import {
+  ArrowCounterClockwise,
+  CaretDown,
+  CaretUp,
+} from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { useCollectableFilterParams } from "@/hooks/params-parsers/use-collectable-filter-params";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -18,6 +22,8 @@ import {
   getSortLabel,
   getSortValueFromLabel,
 } from "@/lib/sort-options";
+import { SearchInput } from "./search-input";
+import { useDebouncedSearch } from "@/hooks/use-debounced-search";
 
 interface MobileNavProps {
   tagOptions: string[];
@@ -34,16 +40,29 @@ export function MobileNav({
 }: MobileNavProps) {
   const [{ view }] = useViewParams();
   const [params, setParams] = useCollectableFilterParams();
-  const { type: selectedType, tags: selectedTags, sort: selectedSort } = params;
+  const {
+    type: selectedType,
+    tags: selectedTags,
+    sort: selectedSort,
+    q: search,
+  } = params;
   const [submissionFormOpen, setSubmissionFormOpen] = useState(false);
+
+  // Shallow, so the query re-runs the grid's client query without a server
+  // round trip for every keystroke.
+  const [searchDraft, setSearchDraft] = useDebouncedSearch(
+    search,
+    (q) => void setParams({ q }, { shallow: true }),
+  );
 
   const hasAnySelection = useMemo(() => {
     return (
       selectedType ||
       (selectedTags && selectedTags.length > 0) ||
+      search !== "" ||
       selectedSort !== DEFAULT_SORT
     );
-  }, [selectedType, selectedTags, selectedSort]);
+  }, [selectedType, selectedTags, search, selectedSort]);
 
   // Helper for showing selected tags as comma-separated
   function toTitleCase(str: string) {
@@ -100,7 +119,6 @@ export function MobileNav({
         <div className="flex items-center justify-between">
           {/* Logo */}
           <Logo align="left" className="h-12 w-36" />
-
         </div>
       </div>
 
@@ -126,7 +144,10 @@ export function MobileNav({
         </button>
 
         {/* Stacked, full-width controls */}
-        <div ref={sheetContentRef} className="flex w-full flex-col gap-2.5 pb-5">
+        <div
+          ref={sheetContentRef}
+          className="flex w-full flex-col gap-2.5 pb-5"
+        >
           {view === "case-study" ? (
             <MobileCaseStudyFilter
               typeOptions={caseStudyTypeOptions}
@@ -134,6 +155,12 @@ export function MobileNav({
             />
           ) : (
             <>
+              <SearchInput
+                value={searchDraft}
+                onValueChange={setSearchDraft}
+                className="h-auto w-full px-5 py-3"
+              />
+
               {/* Type Dropdown */}
               <button
                 onClick={() => setTypeOpen(true)}
@@ -202,6 +229,7 @@ export function MobileNav({
                       ...params,
                       type: null,
                       tags: [],
+                      q: null,
                       sort: DEFAULT_SORT,
                     })
                   }

--- a/src/components/nav/search-input.tsx
+++ b/src/components/nav/search-input.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { MagnifyingGlass, X } from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
+
+export const SEARCH_PLACEHOLDER = "Search name, expertise, keywords";
+
+interface SearchInputProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+/**
+ * Presentational only — the debounce and the URL write live at the call site,
+ * because the designer and case study views keep their query in different
+ * params. Shaped like the filter pills next to it; `className` is how the
+ * mobile sheet stretches it to a full-width row.
+ */
+export function SearchInput({
+  value,
+  onValueChange,
+  placeholder = SEARCH_PLACEHOLDER,
+  className,
+}: SearchInputProps) {
+  return (
+    <div
+      className={cn(
+        "flex h-9 items-center gap-2 rounded-full bg-neutral-200 px-4 text-neutral-900 transition-colors focus-within:bg-neutral-300 hover:bg-neutral-300",
+        className,
+      )}
+    >
+      <MagnifyingGlass weight="bold" className="h-5 w-5 flex-shrink-0" />
+
+      <input
+        type="search"
+        value={value}
+        onChange={(event) => onValueChange(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") onValueChange("");
+        }}
+        placeholder={placeholder}
+        aria-label={placeholder}
+        className="w-full min-w-0 bg-transparent text-base font-normal placeholder:text-neutral-500 focus:outline-none [&::-webkit-search-cancel-button]:appearance-none"
+      />
+
+      {value !== "" && (
+        <button
+          type="button"
+          onClick={() => onValueChange("")}
+          aria-label="Clear search"
+          className="flex flex-shrink-0 items-center justify-center focus:outline-none"
+        >
+          <X weight="bold" className="h-5 w-5" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -6,18 +6,22 @@ import { useState } from "react";
 import { SubmissionForm } from "@/components/submission-form";
 
 /**
- * The site blurb, pinned to the bottom-right corner.
+ * The site's two links, pinned to the bottom-right corner.
  *
- * It used to live in the header's right-hand column, which cost the filter row
- * a third of the width it needed once the sort control arrived. Down here it
- * sits over the grid instead of competing with it, so the whole header width is
- * free for controls.
+ * They used to live in the header's right-hand column, which cost the filter
+ * row a third of the width it needed once the sort control arrived. Down here
+ * they sit over the grid instead of competing with it, so the whole header
+ * width is free for controls.
+ *
+ * Trimmed to the calls to action alone — the sentences that used to introduce
+ * them ("Discover inspiring designers…", "Have someone in mind?") ran wide
+ * enough to reach the search bar centred on the same line. What is left is
+ * short enough for the two to share that line.
  *
  * Cards scroll underneath, so the text needs something behind it to stay
  * readable. That something is painted on the inline text itself rather than on
- * a wrapper, so it hugs each line instead of reading as a panel floating over
- * the grid. `box-decoration-clone` is what gives the second line its own
- * padding instead of the two sharing one box.
+ * a wrapper, so it hugs the line instead of reading as a panel floating over
+ * the grid, with `box-decoration-clone` keeping that true if it ever wraps.
  *
  * Mobile has its own copy of this text inside the Info overlay, and a fixed
  * filter bar in this corner, so this is desktop-only.
@@ -33,7 +37,6 @@ export function SiteFooter() {
       <footer className="pointer-events-none fixed bottom-5 right-6 z-40 hidden text-right text-base leading-relaxed text-neutral-900 md:block">
         <p>
           <span className={LINE_BACKDROP}>
-            Discover inspiring designers. Curated by{" "}
             <Link
               href="https://x.com/notjerrywang"
               target="_blank"
@@ -42,11 +45,7 @@ export function SiteFooter() {
             >
               ↳ @Jerry
             </Link>
-          </span>
-        </p>
-        <p>
-          <span className={LINE_BACKDROP}>
-            Have someone in mind?{" "}
+            {" · "}
             <button
               onClick={() => setIsFormOpen(true)}
               className="underline hover:no-underline"

--- a/src/hooks/params-parsers/use-case-study-filter-params.ts
+++ b/src/hooks/params-parsers/use-case-study-filter-params.ts
@@ -9,17 +9,28 @@ const CASE_STUDY_FILTER_PARAMS = {
     clearOnDefault: true,
     shallow: false,
   }),
+  // Written by the search box, which passes `shallow: true` on the setter so
+  // typing doesn't re-run the server render for every keystroke.
+  q: parseAsString.withDefault("").withOptions({
+    clearOnDefault: true,
+    shallow: false,
+  }),
 };
 
 export function hasAnyCaseStudyFilterApplied(
   filterParams: ReturnType<typeof useCaseStudyFilterParams>[0],
 ) {
-  return filterParams.types.length > 0 || filterParams.industries.length > 0;
+  return (
+    filterParams.types.length > 0 ||
+    filterParams.industries.length > 0 ||
+    filterParams.q !== ""
+  );
 }
 
 export const CASE_STUDY_URL_KEYS = {
   types: "types",
   industries: "industries",
+  q: "q",
 };
 
 export function useCaseStudyFilterParams() {

--- a/src/hooks/params-parsers/use-collectable-filter-params.ts
+++ b/src/hooks/params-parsers/use-collectable-filter-params.ts
@@ -15,6 +15,12 @@ const COLLECTABLE_FILTER_PARAMS = {
     clearOnDefault: true,
     shallow: false,
   }),
+  // Written by the search box, which passes `shallow: true` on the setter so
+  // typing doesn't re-run the server render for every keystroke.
+  q: parseAsString.withDefault("").withOptions({
+    clearOnDefault: true,
+    shallow: false,
+  }),
   sort: parseAsStringLiteral(SORT_VALUES)
     .withDefault(DEFAULT_SORT)
     .withOptions({
@@ -29,6 +35,7 @@ export function hasAnyFilterApplied(
   return (
     filterParams.type !== "" ||
     filterParams.tags.length > 0 ||
+    filterParams.q !== "" ||
     filterParams.sort !== DEFAULT_SORT
   );
 }
@@ -36,6 +43,7 @@ export function hasAnyFilterApplied(
 export const URL_KEYS = {
   type: "type",
   tags: "tags",
+  q: "q",
   sort: "sort",
 };
 

--- a/src/hooks/use-debounced-search.ts
+++ b/src/hooks/use-debounced-search.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const DEBOUNCE_MS = 300;
+
+/**
+ * Keeps a search box responsive while the query lives in the URL.
+ *
+ * The input renders from local state so keystrokes never wait on a round trip,
+ * and the committed value is written a beat after typing stops. The URL still
+ * wins whenever it changes on its own — a reset button, the back button — but
+ * not when the change is our own write coming back, which would otherwise wipe
+ * out anything typed while that write was in flight.
+ */
+export function useDebouncedSearch(
+  value: string,
+  commit: (next: string | null) => void,
+) {
+  const [draft, setDraft] = useState(value);
+  const committedRef = useRef(value);
+  const commitRef = useRef(commit);
+
+  useEffect(() => {
+    commitRef.current = commit;
+  });
+
+  useEffect(() => {
+    if (value === committedRef.current) return;
+
+    committedRef.current = value;
+    setDraft(value);
+  }, [value]);
+
+  useEffect(() => {
+    if (draft === committedRef.current) return;
+
+    const timeout = setTimeout(() => {
+      committedRef.current = draft;
+      commitRef.current(draft === "" ? null : draft);
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(timeout);
+  }, [draft]);
+
+  return [draft, setDraft] as const;
+}

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,40 @@
+/**
+ * Free-text search shared by the designer and case study listings.
+ *
+ * Matching is case-insensitive substring, one `ILIKE` per word, ANDed together:
+ * "brand tokyo" keeps only rows carrying both words somewhere in their searched
+ * columns. Substrings rather than whole words so partial typing works —
+ * "typo" finds "typography" while the query is still being written.
+ */
+
+/** A query longer than this can only be a paste or an attack. */
+const MAX_TERMS = 6;
+const MAX_TERM_LENGTH = 64;
+
+/**
+ * Split a raw query into the words to match. The listing endpoints are public
+ * and unauthenticated, so the caps are what stop one request from building an
+ * unbounded `WHERE` clause.
+ */
+export function parseSearchTerms(query: string | undefined | null): string[] {
+  if (!query) return [];
+
+  return query
+    .trim()
+    .split(/\s+/)
+    .filter((term) => term.length > 0)
+    .slice(0, MAX_TERMS)
+    .map((term) => term.slice(0, MAX_TERM_LENGTH));
+}
+
+/**
+ * Wrap a term for `ILIKE`, escaping the wildcards so a query containing `%` or
+ * `_` matches those characters literally. Postgres treats backslash as the
+ * escape character for `LIKE` by default, so no `ESCAPE` clause is needed — and
+ * the pattern is bound as a parameter, never interpolated.
+ */
+export function toLikePattern(term: string): string {
+  const escaped = term.replace(/[\\%_]/g, (character) => `\\${character}`);
+
+  return `%${escaped}%`;
+}

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -38,3 +38,57 @@ export function toLikePattern(term: string): string {
 
   return `%${escaped}%`;
 }
+
+export interface TextSegment {
+  text: string;
+  matched: boolean;
+}
+
+/**
+ * Split a string into matched and unmatched runs, for highlighting a result
+ * against the query that returned it.
+ *
+ * Runs off a mask rather than a regex. Nothing needs escaping — a query is
+ * ordinary text, and `%` and `_` are already known to reach this far — and
+ * overlapping terms merge into one run instead of fighting over the same
+ * characters, so searching "type typography" marks the word once.
+ *
+ * Terms come from `parseSearchTerms`, the same splitter the routers use to
+ * build their `ILIKE` patterns, so nothing can be highlighted that wasn't
+ * searched for.
+ */
+export function splitOnMatches(text: string, terms: string[]): TextSegment[] {
+  if (terms.length === 0 || text === "") {
+    return [{ text, matched: false }];
+  }
+
+  const haystack = text.toLowerCase();
+  const mask = new Array<boolean>(text.length).fill(false);
+  let anyMatch = false;
+
+  for (const term of terms) {
+    const needle = term.toLowerCase();
+    if (needle === "") continue;
+
+    let from = haystack.indexOf(needle);
+    while (from !== -1) {
+      mask.fill(true, from, from + needle.length);
+      anyMatch = true;
+      from = haystack.indexOf(needle, from + 1);
+    }
+  }
+
+  if (!anyMatch) return [{ text, matched: false }];
+
+  const segments: TextSegment[] = [];
+  let start = 0;
+
+  for (let i = 1; i <= text.length; i++) {
+    if (i === text.length || mask[i] !== mask[start]) {
+      segments.push({ text: text.slice(start, i), matched: mask[start]! });
+      start = i;
+    }
+  }
+
+  return segments;
+}

--- a/src/server/api/routers/case-study.ts
+++ b/src/server/api/routers/case-study.ts
@@ -3,12 +3,29 @@ import { z } from "zod";
 import { createTRPCRouter, publicProcedure } from "@/server/api/trpc";
 import { caseStudies } from "@/server/db/schema";
 import { and, arrayOverlaps, desc, eq, sql } from "drizzle-orm";
+import { parseSearchTerms, toLikePattern } from "@/lib/search";
 
 const CASE_STUDY_PER_PAGE = 12;
+
+/**
+ * The case study half of the designer search: name, the two tag arrays, the
+ * role/team credits, and the AI summary. `sourceText` is the raw scraped page
+ * and is left out — searching it would match nearly every query.
+ */
+function matchesSearch(terms: string[]) {
+  if (terms.length === 0) return sql`TRUE`;
+
+  const haystack = sql`concat_ws(' ', ${caseStudies.name}, ${caseStudies.infoRole}, ${caseStudies.infoTeam}, ${caseStudies.aiSummary}, array_to_string(${caseStudies.types}, ' '), array_to_string(${caseStudies.industries}, ' '))`;
+
+  return and(
+    ...terms.map((term) => sql`${haystack} ILIKE ${toLikePattern(term)}`),
+  );
+}
 
 const FILTER_QUERY_OBJECT = z.object({
   types: z.array(z.string()).optional(),
   industries: z.array(z.string()).optional(),
+  q: z.string().optional(),
 });
 
 const FILTER_QUERY_OBJECT_WITH_PAGINATION = FILTER_QUERY_OBJECT.extend({
@@ -20,7 +37,7 @@ export const caseStudyRouter = createTRPCRouter({
   getInfiniteScroll: publicProcedure
     .input(FILTER_QUERY_OBJECT_WITH_PAGINATION)
     .query(async ({ ctx, input }) => {
-      const { types, industries, cursor, limit } = input;
+      const { types, industries, q, cursor, limit } = input;
 
       const items = await ctx.db
         .selectDistinct({
@@ -49,6 +66,7 @@ export const caseStudyRouter = createTRPCRouter({
             industries && industries.length > 0
               ? arrayOverlaps(caseStudies.industries, industries)
               : sql`TRUE`,
+            matchesSearch(parseSearchTerms(q)),
           ),
         )
         .offset(cursor)

--- a/src/server/api/routers/collectable.ts
+++ b/src/server/api/routers/collectable.ts
@@ -2,17 +2,27 @@ import { z } from "zod";
 
 import { createTRPCRouter, publicProcedure } from "@/server/api/trpc";
 import { collectables } from "@/server/db/schema";
-import {
-  eq,
-  and,
-  sql,
-  arrayOverlaps,
-  asc,
-  desc,
-} from "drizzle-orm";
+import { eq, and, sql, arrayOverlaps, asc, desc } from "drizzle-orm";
 import { DEFAULT_SORT, SORT_VALUES, type SortValue } from "@/lib/sort-options";
+import { parseSearchTerms, toLikePattern } from "@/lib/search";
 
 const COLLECTABLE_PER_PAGE = 12;
+
+/**
+ * Free-text search over name, expertise tags, role, and the AI blurb. The
+ * columns are folded into one string per row — `concat_ws` drops the nulls and
+ * `array_to_string` flattens the tag array — so a term matches wherever it
+ * lands. Location is deliberately not searched.
+ */
+function matchesSearch(terms: string[]) {
+  if (terms.length === 0) return sql`TRUE`;
+
+  const haystack = sql`concat_ws(' ', ${collectables.name}, ${collectables.title}, ${collectables.company}, ${collectables.aiDescription}, array_to_string(${collectables.tags}, ' '))`;
+
+  return and(
+    ...terms.map((term) => sql`${haystack} ILIKE ${toLikePattern(term)}`),
+  );
+}
 
 /**
  * `createdAt` is nullable, so both time-based orderings push nulls to the end
@@ -42,6 +52,7 @@ function getOrderBy(sort: SortValue) {
 const FILTER_QUERY_OBJECT = z.object({
   type: z.string().optional(),
   tags: z.array(z.string()).optional(),
+  q: z.string().optional(),
   sort: z.enum(SORT_VALUES).default(DEFAULT_SORT),
 });
 
@@ -62,7 +73,7 @@ export const collectableRouter = createTRPCRouter({
   getInfiniteScroll: publicProcedure
     .input(FILTER_QUERY_OBJECT_WITH_PAGINATION)
     .query(async ({ ctx, input }) => {
-      const { type, tags, cursor, limit, sort } = input;
+      const { type, tags, q, cursor, limit, sort } = input;
 
       const query = ctx.db
         .selectDistinct({
@@ -87,6 +98,7 @@ export const collectableRouter = createTRPCRouter({
             tags && tags.length > 0
               ? arrayOverlaps(collectables.tags, tags)
               : sql`TRUE`,
+            matchesSearch(parseSearchTerms(q)),
           ),
         )
         .offset(cursor)

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,6 +15,16 @@ export default {
         sm: "calc(var(--radius) - 4px)",
         full: "9999px",
       },
+      boxShadow: {
+        // For the search bar, the one control that floats over the grid rather
+        // than sitting in a row. Two layers, because one reads flat: the tight
+        // one anchors the pill to the page, the wide one carries the height.
+        // Offsets are vertical only, blur is about twice the offset, and the
+        // ambient layer's negative spread keeps it under the pill instead of
+        // bleeding out either side.
+        float:
+          "0 2px 4px -1px rgba(0,0,0,0.10), 0 12px 28px -6px rgba(0,0,0,0.22)",
+      },
       colors: {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
@@ -97,7 +107,8 @@ export default {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
         // Kept in sync with SPIN_DURATION_MS in src/components/nav/logo.tsx.
-        "logo-ball-spin": "logo-ball-spin 0.6s cubic-bezier(0.45, 0, 0.2, 1) both",
+        "logo-ball-spin":
+          "logo-ball-spin 0.6s cubic-bezier(0.45, 0, 0.2, 1) both",
       },
     },
   },


### PR DESCRIPTION
## Summary
This PR adds a full-text search feature to both the designer (collectable) and case study listing pages, allowing users to search by name, expertise, keywords, and other relevant fields alongside existing filter options.

## Key Changes

- **New SearchInput component** (`src/components/nav/search-input.tsx`): A reusable, presentational search input with magnifying glass icon, clear button, and Escape key support. Styled to match filter pills.

- **Debounced search hook** (`src/hooks/use-debounced-search.ts`): Manages responsive search input while keeping the query in the URL. Local state updates immediately for snappy UX, while commits to the URL are debounced (300ms) to avoid excessive server requests. The URL still wins on external changes (back button, reset) without interfering with in-flight writes.

- **Search utilities** (`src/lib/search.ts`): 
  - `parseSearchTerms()`: Splits queries into words with safety limits (max 6 terms, 64 chars each)
  - `toLikePattern()`: Escapes wildcards for safe `ILIKE` pattern matching

- **Backend search implementation**:
  - **Collectable router**: Searches across name, title, company, AI description, and expertise tags using `concat_ws` and `array_to_string` for flexible matching
  - **Case study router**: Searches across name, role/team credits, AI summary, and both type/industry tag arrays
  - Both use case-insensitive substring matching with AND logic (all terms must match)

- **Filter UI updates**:
  - `HorizontalFilter`: Search input now appears first; filter dropdowns conditionally render only if options exist, but search always shows
  - `CaseStudyFilter` & `MobileCaseStudyFilter`: Similar pattern with search always available
  - `MobileNav`: Integrated search input into mobile sheet

- **URL parameter handling**: Added `q` parameter to filter params parsers for both collectable and case study views, with shallow updates to avoid server re-renders on every keystroke

- **Reset button**: Updated to clear search along with other filters

## Implementation Details

- Search uses `shallow: true` on URL writes to keep the client-side grid query responsive without triggering server-side re-renders for every keystroke
- Substring matching (not whole-word) enables partial typing to work naturally
- Multiple search terms are ANDed together for precise filtering
- Search input styling matches existing filter pills for visual consistency
- The debounce hook carefully manages the relationship between local draft state and URL-committed state to handle back button and reset scenarios correctly

https://claude.ai/code/session_01TeXrQJmpc3wj2KvPN552Dn