### PR TITLE
Add sorting functionality to case study filters

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import { MobileNav } from "@/components/nav/mobile-nav";
 import CollectableGrid from "@/components/collectable-grid";
 import CaseStudyGrid from "@/components/case-study-grid";
 import { SiteFooter } from "@/components/site-footer";
-import { DEFAULT_SORT } from "@/lib/sort-options";
+import { CASE_STUDY_DEFAULT_SORT, DEFAULT_SORT } from "@/lib/sort-options";
 
 const COLLECTABLE_PER_PAGE = 12;
 
@@ -60,6 +60,7 @@ export default async function Home({ searchParams }: HomeProps) {
     const initialCaseStudies = await api.caseStudy.getInfiniteScroll({
       types: [],
       industries: [],
+      sort: CASE_STUDY_DEFAULT_SORT,
       limit: COLLECTABLE_PER_PAGE,
     });
 

--- a/src/components/case-study-grid.tsx
+++ b/src/components/case-study-grid.tsx
@@ -30,6 +30,7 @@ function CaseStudyGrid({ initialData, pageSize }: CaseStudyGridProps) {
       limit: pageSize,
       types: filterParams.types,
       industries: filterParams.industries,
+      sort: filterParams.sort,
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,

--- a/src/components/nav/case-study-filter.tsx
+++ b/src/components/nav/case-study-filter.tsx
@@ -6,6 +6,11 @@ import { useCaseStudyFilterParams } from "@/hooks/params-parsers/use-case-study-
 import { useMemo, useState } from "react";
 import { DropdownMenu } from "@/components/ui/dropdown-menu";
 import { motion } from "motion/react";
+import {
+  CASE_STUDY_DEFAULT_SORT,
+  SORT_OPTIONS,
+  getSortLabel,
+} from "@/lib/sort-options";
 
 interface CaseStudyFilterProps {
   typeOptions: string[];
@@ -34,14 +39,22 @@ export function CaseStudyFilter({
   industryOptions,
 }: CaseStudyFilterProps) {
   const [params, setParams] = useCaseStudyFilterParams();
-  const { types: selectedTypes, industries: selectedIndustries } = params;
+  const {
+    types: selectedTypes,
+    industries: selectedIndustries,
+    sort: selectedSort,
+  } = params;
 
   const [typeOpen, setTypeOpen] = useState(false);
   const [industryOpen, setIndustryOpen] = useState(false);
+  const [sortOpen, setSortOpen] = useState(false);
 
   const hasAnySelection = useMemo(
-    () => selectedTypes.length > 0 || selectedIndustries.length > 0,
-    [selectedTypes, selectedIndustries],
+    () =>
+      selectedTypes.length > 0 ||
+      selectedIndustries.length > 0 ||
+      selectedSort !== CASE_STUDY_DEFAULT_SORT,
+    [selectedTypes, selectedIndustries, selectedSort],
   );
 
   const toggle = (key: "types" | "industries", value: string) => {
@@ -62,10 +75,9 @@ export function CaseStudyFilter({
         : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
     );
 
-  // An empty database means empty dropdowns — show nothing rather than
-  // controls that can't do anything.
-  if (typeOptions.length === 0 && industryOptions.length === 0) return null;
-
+  // The type and industry dropdowns each drop out when the database has
+  // nothing to put in them. There's no early return for the whole row the way
+  // there used to be: sort needs no options table, so it's always offered.
   return (
     <div className="flex items-center gap-2.5 pb-0 pt-0">
       {typeOptions.length > 0 && (
@@ -140,11 +152,43 @@ export function CaseStudyFilter({
         </DropdownMenu.Root>
       )}
 
+      <DropdownMenu.Root open={sortOpen} onOpenChange={setSortOpen}>
+        <DropdownMenu.Trigger asChild>
+          <button className={triggerClasses(sortOpen)}>
+            {getSortLabel(selectedSort)}
+            <motion.div
+              animate={{ rotate: sortOpen ? 180 : 0 }}
+              transition={{ duration: 0.2, ease: "easeInOut" }}
+            >
+              <CaretDown weight="fill" className="h-5 w-5" />
+            </motion.div>
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content open={sortOpen}>
+          {SORT_OPTIONS.map((option) => (
+            <DropdownMenu.Item
+              key={option.value}
+              onSelect={() => void setParams({ ...params, sort: option.value })}
+              selected={selectedSort === option.value}
+            >
+              {option.label}
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+
       {/* Only takes up space once there's something to reset — the header
           column is narrow enough that the idle 36px matters. */}
       {hasAnySelection && (
         <button
-          onClick={() => setParams({ ...params, types: [], industries: [] })}
+          onClick={() =>
+            setParams({
+              ...params,
+              types: [],
+              industries: [],
+              sort: CASE_STUDY_DEFAULT_SORT,
+            })
+          }
           className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-neutral-200 text-neutral-900 transition-all hover:bg-neutral-300"
           aria-label="Reset filters"
         >

--- a/src/components/nav/mobile-case-study-filter.tsx
+++ b/src/components/nav/mobile-case-study-filter.tsx
@@ -6,6 +6,12 @@ import { motion } from "motion/react";
 import { cn } from "@/lib/utils";
 import { MobileDropdown } from "@/components/ui/mobile-dropdown";
 import { useCaseStudyFilterParams } from "@/hooks/params-parsers/use-case-study-filter-params";
+import {
+  CASE_STUDY_DEFAULT_SORT,
+  SORT_OPTIONS,
+  getSortLabel,
+  getSortValueFromLabel,
+} from "@/lib/sort-options";
 
 interface MobileCaseStudyFilterProps {
   typeOptions: string[];
@@ -31,14 +37,22 @@ export function MobileCaseStudyFilter({
   industryOptions,
 }: MobileCaseStudyFilterProps) {
   const [params, setParams] = useCaseStudyFilterParams();
-  const { types: selectedTypes, industries: selectedIndustries } = params;
+  const {
+    types: selectedTypes,
+    industries: selectedIndustries,
+    sort: selectedSort,
+  } = params;
 
   const [typeOpen, setTypeOpen] = useState(false);
   const [industryOpen, setIndustryOpen] = useState(false);
+  const [sortOpen, setSortOpen] = useState(false);
 
   const hasAnySelection = useMemo(
-    () => selectedTypes.length > 0 || selectedIndustries.length > 0,
-    [selectedTypes, selectedIndustries],
+    () =>
+      selectedTypes.length > 0 ||
+      selectedIndustries.length > 0 ||
+      selectedSort !== CASE_STUDY_DEFAULT_SORT,
+    [selectedTypes, selectedIndustries, selectedSort],
   );
 
   const toggle = (key: "types" | "industries", value: string) => {
@@ -59,10 +73,8 @@ export function MobileCaseStudyFilter({
         : "bg-neutral-200 text-neutral-900 hover:bg-neutral-300",
     );
 
-  // No options means no filters to show — the sheet still carries the view
-  // toggle and Info, so only these controls drop out.
-  if (typeOptions.length === 0 && industryOptions.length === 0) return null;
-
+  // No options means the type and industry buttons drop out of the sheet, but
+  // sort needs no options table, so it's always offered.
   return (
     <>
       {typeOptions.length > 0 && (
@@ -101,9 +113,30 @@ export function MobileCaseStudyFilter({
         </button>
       )}
 
+      <button
+        onClick={() => setSortOpen(true)}
+        className={triggerClasses(sortOpen)}
+      >
+        <span className="truncate">{getSortLabel(selectedSort)}</span>
+        <motion.div
+          animate={{ rotate: sortOpen ? 180 : 0 }}
+          transition={{ duration: 0.2, ease: "easeInOut" }}
+          className="flex-shrink-0"
+        >
+          <CaretDown weight="fill" className="h-5 w-5" />
+        </motion.div>
+      </button>
+
       {hasAnySelection && (
         <button
-          onClick={() => setParams({ ...params, types: [], industries: [] })}
+          onClick={() =>
+            setParams({
+              ...params,
+              types: [],
+              industries: [],
+              sort: CASE_STUDY_DEFAULT_SORT,
+            })
+          }
           className="flex w-full items-center justify-between gap-2 rounded-full bg-neutral-200 px-5 py-3 text-base font-normal text-neutral-900 transition-colors hover:bg-neutral-300"
           aria-label="Reset filters"
         >
@@ -135,6 +168,20 @@ export function MobileCaseStudyFilter({
         selectedOptions={selectedIndustries}
         onOptionSelect={(industry) => toggle("industries", industry)}
         multiSelect={true}
+      />
+
+      <MobileDropdown
+        open={sortOpen}
+        onOpenChange={setSortOpen}
+        options={SORT_OPTIONS.map((option) => option.label)}
+        selectedOptions={[getSortLabel(selectedSort)]}
+        onOptionSelect={(label) => {
+          const sort = getSortValueFromLabel(label);
+          if (sort) {
+            void setParams({ ...params, sort });
+          }
+        }}
+        multiSelect={false}
       />
     </>
   );

--- a/src/hooks/params-parsers/use-case-study-filter-params.ts
+++ b/src/hooks/params-parsers/use-case-study-filter-params.ts
@@ -1,4 +1,10 @@
-import { parseAsArrayOf, parseAsString, useQueryStates } from "nuqs";
+import {
+  parseAsArrayOf,
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryStates,
+} from "nuqs";
+import { CASE_STUDY_DEFAULT_SORT, SORT_VALUES } from "@/lib/sort-options";
 
 const CASE_STUDY_FILTER_PARAMS = {
   types: parseAsArrayOf(parseAsString).withDefault([]).withOptions({
@@ -9,17 +15,28 @@ const CASE_STUDY_FILTER_PARAMS = {
     clearOnDefault: true,
     shallow: false,
   }),
+  sort: parseAsStringLiteral(SORT_VALUES)
+    .withDefault(CASE_STUDY_DEFAULT_SORT)
+    .withOptions({
+      clearOnDefault: true,
+      shallow: false,
+    }),
 };
 
 export function hasAnyCaseStudyFilterApplied(
   filterParams: ReturnType<typeof useCaseStudyFilterParams>[0],
 ) {
-  return filterParams.types.length > 0 || filterParams.industries.length > 0;
+  return (
+    filterParams.types.length > 0 ||
+    filterParams.industries.length > 0 ||
+    filterParams.sort !== CASE_STUDY_DEFAULT_SORT
+  );
 }
 
 export const CASE_STUDY_URL_KEYS = {
   types: "types",
   industries: "industries",
+  sort: "sort",
 };
 
 export function useCaseStudyFilterParams() {

--- a/src/lib/sort-options.ts
+++ b/src/lib/sort-options.ts
@@ -9,6 +9,13 @@ export type SortValue = (typeof SORT_VALUES)[number];
 
 export const DEFAULT_SORT: SortValue = "name-asc";
 
+/**
+ * Projects have always landed newest first, and the grid is read as a feed
+ * rather than a directory, so they keep that default instead of the
+ * alphabetical one the designer list uses.
+ */
+export const CASE_STUDY_DEFAULT_SORT: SortValue = "recent";
+
 export const SORT_OPTIONS: { value: SortValue; label: string }[] = [
   { value: "recent", label: "Recently Added" },
   { value: "earliest", label: "Earliest Added" },

--- a/src/server/api/routers/case-study.ts
+++ b/src/server/api/routers/case-study.ts
@@ -2,13 +2,16 @@ import { z } from "zod";
 
 import { createTRPCRouter, publicProcedure } from "@/server/api/trpc";
 import { caseStudies } from "@/server/db/schema";
-import { and, arrayOverlaps, desc, eq, sql } from "drizzle-orm";
+import { and, arrayOverlaps, eq, sql } from "drizzle-orm";
+import { CASE_STUDY_DEFAULT_SORT, SORT_VALUES } from "@/lib/sort-options";
+import { getOrderBy } from "@/server/api/sort-order";
 
 const CASE_STUDY_PER_PAGE = 12;
 
 const FILTER_QUERY_OBJECT = z.object({
   types: z.array(z.string()).optional(),
   industries: z.array(z.string()).optional(),
+  sort: z.enum(SORT_VALUES).default(CASE_STUDY_DEFAULT_SORT),
 });
 
 const FILTER_QUERY_OBJECT_WITH_PAGINATION = FILTER_QUERY_OBJECT.extend({
@@ -20,7 +23,7 @@ export const caseStudyRouter = createTRPCRouter({
   getInfiniteScroll: publicProcedure
     .input(FILTER_QUERY_OBJECT_WITH_PAGINATION)
     .query(async ({ ctx, input }) => {
-      const { types, industries, cursor, limit } = input;
+      const { types, industries, cursor, limit, sort } = input;
 
       const items = await ctx.db
         .selectDistinct({
@@ -52,7 +55,7 @@ export const caseStudyRouter = createTRPCRouter({
           ),
         )
         .offset(cursor)
-        .orderBy(desc(caseStudies.createdAt));
+        .orderBy(...getOrderBy(caseStudies, sort));
 
       return {
         items: items.slice(0, limit),

--- a/src/server/api/routers/collectable.ts
+++ b/src/server/api/routers/collectable.ts
@@ -2,42 +2,11 @@ import { z } from "zod";
 
 import { createTRPCRouter, publicProcedure } from "@/server/api/trpc";
 import { collectables } from "@/server/db/schema";
-import {
-  eq,
-  and,
-  sql,
-  arrayOverlaps,
-  asc,
-  desc,
-} from "drizzle-orm";
-import { DEFAULT_SORT, SORT_VALUES, type SortValue } from "@/lib/sort-options";
+import { eq, and, sql, arrayOverlaps } from "drizzle-orm";
+import { DEFAULT_SORT, SORT_VALUES } from "@/lib/sort-options";
+import { getOrderBy } from "@/server/api/sort-order";
 
 const COLLECTABLE_PER_PAGE = 12;
-
-/**
- * `createdAt` is nullable, so both time-based orderings push nulls to the end
- * rather than letting Postgres default them to the top of a DESC sort. Name is
- * the tiebreaker so offset pagination stays deterministic.
- */
-function getOrderBy(sort: SortValue) {
-  switch (sort) {
-    case "recent":
-      return [
-        sql`${collectables.createdAt} DESC NULLS LAST`,
-        asc(collectables.name),
-      ];
-    case "earliest":
-      return [
-        sql`${collectables.createdAt} ASC NULLS LAST`,
-        asc(collectables.name),
-      ];
-    case "name-desc":
-      return [desc(collectables.name)];
-    case "name-asc":
-    default:
-      return [asc(collectables.name)];
-  }
-}
 
 const FILTER_QUERY_OBJECT = z.object({
   type: z.string().optional(),
@@ -90,7 +59,7 @@ export const collectableRouter = createTRPCRouter({
           ),
         )
         .offset(cursor)
-        .orderBy(...getOrderBy(sort));
+        .orderBy(...getOrderBy(collectables, sort));
 
       const items = await query;
       let nextCursor: number | undefined = undefined;

--- a/src/server/api/sort-order.ts
+++ b/src/server/api/sort-order.ts
@@ -1,0 +1,27 @@
+import { asc, desc, sql, type SQL } from "drizzle-orm";
+import type { PgColumn } from "drizzle-orm/pg-core";
+
+import type { SortValue } from "@/lib/sort-options";
+
+/**
+ * `createdAt` is nullable on every sortable table, so both time-based
+ * orderings push nulls to the end rather than letting Postgres default them to
+ * the top of a DESC sort. Name is the tiebreaker so offset pagination stays
+ * deterministic.
+ */
+export function getOrderBy(
+  columns: { createdAt: PgColumn; name: PgColumn },
+  sort: SortValue,
+): SQL[] {
+  switch (sort) {
+    case "recent":
+      return [sql`${columns.createdAt} DESC NULLS LAST`, asc(columns.name)];
+    case "earliest":
+      return [sql`${columns.createdAt} ASC NULLS LAST`, asc(columns.name)];
+    case "name-desc":
+      return [desc(columns.name)];
+    case "name-asc":
+    default:
+      return [asc(columns.name)];
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds sorting capabilities to the case study filter interface, allowing users to sort case studies by creation date (recent/earliest) or name (ascending/descending). The sorting feature is integrated into both desktop and mobile filter components, with a separate default sort value for case studies ("recent") distinct from the collectable list default ("name-asc").

## Key Changes

- **New sort parameter in case study filters**: Added `sort` parameter to `useCaseStudyFilterParams` hook with `CASE_STUDY_DEFAULT_SORT` ("recent") as the default
- **Sort UI components**: Added sort dropdown buttons to both `CaseStudyFilter` (desktop) and `MobileCaseStudyFilter` components with animated caret indicators
- **Extracted sort logic**: Moved `getOrderBy` function to a new shared module (`src/server/api/sort-order.ts`) to support sorting across multiple routers (collectable and case-study)
- **Updated API routers**: Modified both `case-study.ts` and `collectable.ts` routers to use the new `getOrderBy` function with proper null handling for `createdAt` fields
- **Reset functionality**: Updated reset buttons to also clear the sort parameter back to the default
- **Filter state tracking**: Updated `hasAnySelection` logic to include sort parameter in determining if filters are active

## Implementation Details

- The `getOrderBy` function now accepts a columns object parameter to support multiple table schemas while maintaining consistent null-handling behavior for nullable `createdAt` fields
- Sort options are displayed using the existing `DropdownMenu` (desktop) and `MobileDropdown` (mobile) components
- The sort parameter is properly integrated into the URL query state using `parseAsStringLiteral` for type safety
- Case studies use "recent" as the default sort (newest first, matching the feed-like grid presentation), while collectables use "name-asc" (alphabetical)

https://claude.ai/code/session_01VGeX1zgyJ223oo3JJbRacw