### PR TITLE
Add designer avatars and site screenshots to directory cards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@ NOTION_API_KEY="secret_1234567890"
 # syncs run as normal and the rows simply carry no blurb.
 ANTHROPIC_API_KEY="sk-ant-1234567890"
 
+# Optional. Captures the site screenshots used as card covers, on both grids.
+# Without it microlink still answers, but on a free tier of a few dozen requests
+# a day — enough to try the feature, not enough to fill a directory. Rows that
+# come back rate-limited keep their place in the queue and are retried.
+SCREENSHOT_API_KEY="1234567890"
+
 # --- Case studies (all optional) ---------------------------------------------
 # The app builds and serves the designer view without any of these. Leave them
 # unset and the case study sync simply no-ops.

--- a/src/app/api/case-study-sync/route.ts
+++ b/src/app/api/case-study-sync/route.ts
@@ -62,7 +62,7 @@ async function enrichCaseStudy(item: NotionCaseStudy) {
 
   const coverImageUrl =
     !isVideo && item.websiteUrl
-      ? await fetchScreenshotUrl(item.websiteUrl)
+      ? (await fetchScreenshotUrl(item.websiteUrl)).url
       : null;
 
   const aiSummary = await generateSummary({

--- a/src/app/api/notion-sync/route.ts
+++ b/src/app/api/notion-sync/route.ts
@@ -1,10 +1,22 @@
 import { NextResponse } from "next/server";
 import { fetchNotionData } from "@/lib/notion-sync";
 import { generateDesignerProfile } from "@/lib/ai-summary";
+import { fetchSiteMeta } from "@/lib/site-meta";
+import { fetchScreenshotUrl } from "@/lib/screenshot";
+import { fetchAvatarUrl } from "@/lib/twitter-avatar";
 import { db } from "@/server/db";
 import { collectables } from "@/server/db/schema";
-import { and, eq, inArray, isNull, or, sql } from "drizzle-orm";
-import * as cheerio from "cheerio";
+import {
+  and,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  or,
+  sql,
+  type SQL,
+} from "drizzle-orm";
+import type { AnyPgColumn } from "drizzle-orm/pg-core";
 
 export const maxDuration = 60;
 
@@ -28,6 +40,79 @@ const PROFILE_BACKFILL_MAX = 100;
 // cooldown instead of consuming every run's budget in perpetuity. A row with
 // all four fields is never read again.
 const PROFILE_RETRY_DAYS = 30;
+
+// The meta pass reads the site itself, so it is cheaper per row than a profile
+// — but it used to run against every stale row at once under the same 60s
+// ceiling, which only held because most of those fetches failed fast. Now that
+// it also looks for a handle it gets a budget of its own, on the same terms.
+const META_BACKFILL_PER_RUN = 40;
+const META_BACKFILL_MAX = 200;
+const META_RETRY_DAYS = 30;
+
+// Capture is the expensive one: a third-party render, rate-limited to a few
+// dozen a day unless SCREENSHOT_API_KEY is set. A small slice per run is the
+// point rather than a limitation — `?screenshots=` sweeps harder by hand.
+const SCREENSHOT_BACKFILL_PER_RUN = 20;
+const SCREENSHOT_BACKFILL_MAX = 100;
+const SCREENSHOT_RETRY_DAYS = 30;
+
+// Only rows that already found a handle reach this pass, so the eligible set is
+// small and each row is one redirect plus a copy into Blob.
+const AVATAR_BACKFILL_PER_RUN = 40;
+const AVATAR_BACKFILL_MAX = 200;
+const AVATAR_RETRY_DAYS = 30;
+
+/** `?name=N`, clamped, or the standing per-run slice. */
+function budgetFrom(
+  params: URLSearchParams,
+  name: string,
+  fallback: number,
+  ceiling: number,
+): number {
+  const requested = Number(params.get(name) ?? "");
+  return Number.isFinite(requested) && requested > 0
+    ? Math.min(Math.trunc(requested), ceiling)
+    : fallback;
+}
+
+/** Column is null, or was last written longer ago than the retry window. */
+function staleOrMissing(column: AnyPgColumn, days: number) {
+  return or(
+    isNull(column),
+    sql`${column} < NOW() - INTERVAL '${sql.raw(`${days} days`)}'`,
+  );
+}
+
+/**
+ * Rows whose site is worth reading again: either it has never given up an OG
+ * image or a handle, or whatever it gave has gone stale.
+ *
+ * The cooldown is what makes the handle condition safe. Most designers never
+ * link a profile anywhere, so `twitterHandle IS NULL` on its own would leave
+ * the majority of the directory permanently eligible and the queue would never
+ * drain past them — the same trap `incompleteProfiles` is fenced against.
+ */
+function sitesToRead() {
+  return and(
+    or(isNull(collectables.ogImageUrl), isNull(collectables.twitterHandle)),
+    staleOrMissing(collectables.ogImageLastFetchedAt, META_RETRY_DAYS),
+  );
+}
+
+function screenshotsToTake() {
+  return and(
+    isNull(collectables.screenshotUrl),
+    staleOrMissing(collectables.screenshotLastFetchedAt, SCREENSHOT_RETRY_DAYS),
+  );
+}
+
+function avatarsToFetch() {
+  return and(
+    isNotNull(collectables.twitterHandle),
+    isNull(collectables.avatarUrl),
+    staleOrMissing(collectables.avatarLastFetchedAt, AVATAR_RETRY_DAYS),
+  );
+}
 
 /** Rows with something still missing, whatever their last reading said. */
 function incompleteProfiles() {
@@ -65,39 +150,47 @@ async function cleanupOrphanedTags() {
   try {
     // Get all tags currently in use in Notion
     const notionItems = await fetchNotionData();
-    const validTags = new Set(
-      notionItems.flatMap(item => item.tags)
+    const validTags = new Set(notionItems.flatMap((item) => item.tags));
+
+    console.log(
+      `Found ${validTags.size} valid tags in Notion:`,
+      Array.from(validTags).sort(),
     );
-    
-    console.log(`Found ${validTags.size} valid tags in Notion:`, Array.from(validTags).sort());
-    
+
     // Find all records with orphaned tags and update them
     const allDbItems = await db.query.collectables.findMany();
-    
-    const itemsWithOrphanedTags = allDbItems.filter(item => 
-      item.tags?.some(tag => !validTags.has(tag))
+
+    const itemsWithOrphanedTags = allDbItems.filter((item) =>
+      item.tags?.some((tag) => !validTags.has(tag)),
     );
-    
+
     if (itemsWithOrphanedTags.length > 0) {
-      console.log(`Found ${itemsWithOrphanedTags.length} items with orphaned tags:`);
-      itemsWithOrphanedTags.forEach(item => {
-        const orphanedTags = item.tags?.filter(tag => !validTags.has(tag)) ?? [];
-        console.log(`  - ${item.name}: removing tags [${orphanedTags.join(', ')}]`);
+      console.log(
+        `Found ${itemsWithOrphanedTags.length} items with orphaned tags:`,
+      );
+      itemsWithOrphanedTags.forEach((item) => {
+        const orphanedTags =
+          item.tags?.filter((tag) => !validTags.has(tag)) ?? [];
+        console.log(
+          `  - ${item.name}: removing tags [${orphanedTags.join(", ")}]`,
+        );
       });
     }
-    
-    const cleanupPromises = itemsWithOrphanedTags.map(item => 
+
+    const cleanupPromises = itemsWithOrphanedTags.map((item) =>
       db
         .update(collectables)
         .set({
-          tags: item.tags?.filter(tag => validTags.has(tag)) ?? []
+          tags: item.tags?.filter((tag) => validTags.has(tag)) ?? [],
         })
-        .where(eq(collectables.id, item.id))
+        .where(eq(collectables.id, item.id)),
     );
-      
+
     if (cleanupPromises.length > 0) {
       await Promise.all(cleanupPromises);
-      console.log(`Successfully cleaned up ${cleanupPromises.length} records with orphaned tags`);
+      console.log(
+        `Successfully cleaned up ${cleanupPromises.length} records with orphaned tags`,
+      );
     } else {
       console.log("No orphaned tags found to clean up");
     }
@@ -108,11 +201,30 @@ async function cleanupOrphanedTags() {
 
 export async function GET(request: Request) {
   const params = new URL(request.url).searchParams;
-  const requested = Number(params.get("profiles") ?? "");
-  const profileBudget =
-    Number.isFinite(requested) && requested > 0
-      ? Math.min(Math.trunc(requested), PROFILE_BACKFILL_MAX)
-      : PROFILE_BACKFILL_PER_RUN;
+  const profileBudget = budgetFrom(
+    params,
+    "profiles",
+    PROFILE_BACKFILL_PER_RUN,
+    PROFILE_BACKFILL_MAX,
+  );
+  const metaBudget = budgetFrom(
+    params,
+    "meta",
+    META_BACKFILL_PER_RUN,
+    META_BACKFILL_MAX,
+  );
+  const screenshotBudget = budgetFrom(
+    params,
+    "screenshots",
+    SCREENSHOT_BACKFILL_PER_RUN,
+    SCREENSHOT_BACKFILL_MAX,
+  );
+  const avatarBudget = budgetFrom(
+    params,
+    "avatars",
+    AVATAR_BACKFILL_PER_RUN,
+    AVATAR_BACKFILL_MAX,
+  );
   const ignoreCooldown = params.get("refresh") === "1";
 
   const trueItems = await fetchNotionData();
@@ -136,6 +248,7 @@ export async function GET(request: Request) {
           updatedAt: new Date(item.updatedAt),
           type: item.type,
           tags: item.tags,
+          twitterHandle: item.twitterHandle,
         })),
       ),
     );
@@ -166,7 +279,27 @@ export async function GET(request: Request) {
         // instead would trade a description that is usually still true — most
         // moved URLs are the same designer on a new host — for an empty card
         // whenever the new page cannot be read.
-        ...(urlAltered ? { isReported: false, isBroken: false } : {}),
+        //
+        // The pictures go, though, unlike the profile: a screenshot is a
+        // portrait of one specific page rather than of the designer, and
+        // showing the old site under the new link is a plain error rather than
+        // a stale detail. The handle and its avatar follow, since both were
+        // read off that same page.
+        ...(urlAltered
+          ? {
+              isReported: false,
+              isBroken: false,
+              screenshotUrl: null,
+              screenshotLastFetchedAt: null,
+              twitterHandle: null,
+              avatarUrl: null,
+              avatarLastFetchedAt: null,
+            }
+          : {}),
+        // Notion is the owner's override and outranks anything scraped, but
+        // only when they actually filled it in — an empty cell must not wipe a
+        // handle the sync found on its own.
+        ...(item.twitterHandle ? { twitterHandle: item.twitterHandle } : {}),
       })
       .where(eq(collectables.id, item.id));
   });
@@ -200,8 +333,6 @@ export async function GET(request: Request) {
   await cleanupOrphanedTags();
   console.log("Finished orphaned tags cleanup");
 
-  // Fetch OG image for altered row / new rows
-
   const urlAlteredItems = updatedItems.filter((item) => {
     const urlAltered =
       dbItems.find((dbItem) => dbItem.id === item.id)?.websiteUrl !==
@@ -209,75 +340,78 @@ export async function GET(request: Request) {
     return urlAltered;
   });
 
-  const itemsToFetchOpenGraph = [...urlAlteredItems, ...newItems];
+  // Rows pointing somewhere new go first, then the backfill fills what is left
+  // of the slice. Every pass below takes the same shape.
+  const priorityItems = [...urlAlteredItems, ...newItems].map((item) => ({
+    id: item.id,
+    websiteUrl: item.websiteUrl,
+  }));
 
-  const ogFetchPromises = itemsToFetchOpenGraph.map((item) =>
-    fetchOpenGraphAndUpdateDb(item.id, item.websiteUrl),
+  const itemsToReadSite = await withBackfill(
+    priorityItems,
+    metaBudget,
+    sitesToRead(),
+    collectables.ogImageLastFetchedAt,
+    (row) => ({ id: row.id, websiteUrl: row.websiteUrl }),
   );
-  console.log("Fetching OG images for", itemsToFetchOpenGraph.length, "items");
-  console.log("Started fetching OG images at", new Date().toISOString());
-  await Promise.all(ogFetchPromises);
-  console.log("Fetched OG images for", itemsToFetchOpenGraph.length, "items");
-  console.log("Finished fetching OG images at", new Date().toISOString());
 
-  // Fetch for items with nullish ogImageUrl or outdated ogImageUrl (older than 30 days)
-  const itemsWithNullishOgImageUrl = await db.query.collectables.findMany({
-    where: or(
-      isNull(collectables.ogImageUrl),
-      sql`${collectables.ogImageLastFetchedAt} < NOW() - INTERVAL '30 days'`,
-    ),
-  });
+  console.log("Reading site meta for", itemsToReadSite.length, "items");
+  await Promise.all(itemsToReadSite.map(readSiteMetaAndUpdateDb));
+  console.log("Finished reading site meta at", new Date().toISOString());
 
-  console.log(
-    "Fetching OG images for",
-    itemsWithNullishOgImageUrl.length,
-    "items",
+  // Runs after the meta pass rather than beside it: a row that just gave up a
+  // handle has a null avatar stamp, which sorts to the front here, so a new
+  // designer gets their face on the same run that finds it.
+  const itemsToAvatar = await withBackfill(
+    [],
+    avatarBudget,
+    avatarsToFetch(),
+    collectables.avatarLastFetchedAt,
+    (row) => ({ id: row.id, twitterHandle: row.twitterHandle }),
   );
-  console.log("Started fetching OG images at", new Date().toISOString());
-  const ogFetchPromisesForNullishOgImageUrl = itemsWithNullishOgImageUrl.map(
-    (item) => fetchOpenGraphAndUpdateDb(item.id, item.websiteUrl),
+
+  console.log("Fetching avatars for", itemsToAvatar.length, "items");
+  const avatarResults = await Promise.all(
+    itemsToAvatar.map(fetchAvatarAndUpdateDb),
   );
-  await Promise.all(ogFetchPromisesForNullishOgImageUrl);
-  console.log(
-    "Fetched OG images for",
-    itemsWithNullishOgImageUrl.length,
-    "items",
+  console.log("Finished fetching avatars at", new Date().toISOString());
+
+  const itemsToScreenshot = await withBackfill(
+    priorityItems,
+    screenshotBudget,
+    screenshotsToTake(),
+    collectables.screenshotLastFetchedAt,
+    (row) => ({ id: row.id, websiteUrl: row.websiteUrl }),
   );
-  console.log("Finished fetching OG images at", new Date().toISOString());
+
+  console.log("Capturing screenshots for", itemsToScreenshot.length, "items");
+  const screenshotResults = await Promise.all(
+    itemsToScreenshot.map(captureScreenshotAndUpdateDb),
+  );
+  console.log("Finished capturing screenshots at", new Date().toISOString());
 
   // Read rows whose URL is new or has moved — the old profile belongs to a page
   // this entry no longer points at — then spend what is left of the per-run
   // budget backfilling rows that have never been read.
-  const itemsToProfile: DescribableItem[] = [
-    ...urlAlteredItems,
-    ...newItems,
-  ].map((item) => ({
-    id: item.id,
-    name: item.name,
-    websiteUrl: item.websiteUrl,
-    type: item.type,
-    tags: item.tags,
-  }));
-
-  const profiledIds = new Set(itemsToProfile.map((item) => item.id));
-  const backfillBudget = profileBudget - itemsToProfile.length;
-
-  if (backfillBudget > 0) {
-    const missingProfile = await db.query.collectables.findMany({
-      where: profilesToRead(ignoreCooldown),
-      // Never-read rows first, then the longest-unread. Without an ordering
-      // Postgres is free to hand back the same rows every run, and the backfill
-      // stalls short of the rows behind them.
-      orderBy: [sql`${collectables.profileGeneratedAt} ASC NULLS FIRST`],
-      limit: backfillBudget + profiledIds.size,
-    });
-
-    itemsToProfile.push(
-      ...missingProfile
-        .filter((item) => !profiledIds.has(item.id))
-        .slice(0, backfillBudget),
-    );
-  }
+  const itemsToProfile = await withBackfill<DescribableItem>(
+    [...urlAlteredItems, ...newItems].map((item) => ({
+      id: item.id,
+      name: item.name,
+      websiteUrl: item.websiteUrl,
+      type: item.type,
+      tags: item.tags,
+    })),
+    profileBudget,
+    profilesToRead(ignoreCooldown),
+    collectables.profileGeneratedAt,
+    (row) => ({
+      id: row.id,
+      name: row.name,
+      websiteUrl: row.websiteUrl,
+      type: row.type,
+      tags: row.tags,
+    }),
+  );
 
   console.log("Generating profiles for", itemsToProfile.length, "items");
   const profileResults = await Promise.all(
@@ -290,11 +424,21 @@ export async function GET(request: Request) {
   // actually missing — they differ by the cooldown, and reporting only the
   // first would read as finished when it means everything was read recently.
   // `unreadable` is the part no further reading can fix.
+  //
+  // The cover counts are read the same way. `withScreenshot` against
+  // `withoutCover` is the one that says whether the grid actually looks the way
+  // this feature intends: the second is rows still falling through to an
+  // initials tile.
   const [standing] = await db
     .select({
       eligible: sql<number>`count(*) FILTER (WHERE ${profilesToRead(false)})::int`,
       incomplete: sql<number>`count(*) FILTER (WHERE ${incompleteProfiles()})::int`,
       unreadable: sql<number>`count(*) FILTER (WHERE ${collectables.profilePageRead} = false)::int`,
+      screenshotsEligible: sql<number>`count(*) FILTER (WHERE ${screenshotsToTake()})::int`,
+      withScreenshot: sql<number>`count(*) FILTER (WHERE ${collectables.screenshotUrl} IS NOT NULL)::int`,
+      withoutCover: sql<number>`count(*) FILTER (WHERE ${collectables.screenshotUrl} IS NULL AND ${collectables.ogImageUrl} IS NULL)::int`,
+      withHandle: sql<number>`count(*) FILTER (WHERE ${collectables.twitterHandle} IS NOT NULL)::int`,
+      withAvatar: sql<number>`count(*) FILTER (WHERE ${collectables.avatarUrl} IS NOT NULL)::int`,
     })
     .from(collectables);
 
@@ -302,14 +446,60 @@ export async function GET(request: Request) {
     newItems: newItems.length,
     updatedItems: updatedItems.length,
     deletedItems: deletedItems.length,
-    itemsWithNullishOgImageUrl: itemsWithNullishOgImageUrl.length,
-    itemsToFetchOpenGraph: itemsToFetchOpenGraph.length,
+    sitesRead: itemsToReadSite.length,
+    screenshotsAttempted: itemsToScreenshot.length,
+    screenshotsCaptured: screenshotResults.filter(Boolean).length,
+    avatarsAttempted: itemsToAvatar.length,
+    avatarsFetched: avatarResults.filter(Boolean).length,
     profilesRead: profileResults.filter(Boolean).length,
     profilesFailed: profileResults.filter((read) => !read).length,
     profilesEligible: standing?.eligible ?? 0,
     profilesIncomplete: standing?.incomplete ?? 0,
     profilesUnreadable: standing?.unreadable ?? 0,
+    screenshotsEligible: standing?.screenshotsEligible ?? 0,
+    withScreenshot: standing?.withScreenshot ?? 0,
+    withoutCover: standing?.withoutCover ?? 0,
+    withHandle: standing?.withHandle ?? 0,
+    withAvatar: standing?.withAvatar ?? 0,
   });
+}
+
+/**
+ * The per-run slice for one pass: rows the sync already knows it must touch,
+ * topped up with the longest-neglected rows matching `where` until the budget
+ * is spent.
+ *
+ * `orderColumn` is what stops the top-up handing back the same rows every run.
+ * Without an ordering Postgres is free to, and the backfill stalls short of the
+ * rows behind them.
+ */
+async function withBackfill<T extends { id: string }>(
+  priority: T[],
+  budget: number,
+  where: SQL | undefined,
+  orderColumn: AnyPgColumn,
+  shape: (row: typeof collectables.$inferSelect) => T,
+): Promise<T[]> {
+  const remaining = budget - priority.length;
+  if (remaining <= 0) return priority;
+
+  const seen = new Set(priority.map((item) => item.id));
+
+  // Over-fetched by the priority count, since those rows usually match `where`
+  // too and would otherwise eat into the top-up.
+  const rows = await db.query.collectables.findMany({
+    where,
+    orderBy: [sql`${orderColumn} ASC NULLS FIRST`],
+    limit: remaining + seen.size,
+  });
+
+  return [
+    ...priority,
+    ...rows
+      .filter((row) => !seen.has(row.id))
+      .slice(0, remaining)
+      .map(shape),
+  ];
 }
 
 /**
@@ -369,35 +559,90 @@ async function generateProfileAndUpdateDb(
   return true;
 }
 
-async function fetchOpenGraph(url: string): Promise<string | null> {
-  try {
-    const response = await fetch(url);
-    const html = await response.text();
-    const $ = cheerio.load(html);
-    let ogImage = $('meta[property="og:image"]').attr("content");
+/**
+ * Reads one row's site for the OG image and the designer's handle.
+ *
+ * The stamp records the reading rather than the result, so it lands even when
+ * the page gave neither. Stamping only on success — which this pass used to do
+ * — meant a site with no OG image was re-fetched on every run for as long as it
+ * stayed in the directory, and the handle lookup would have doubled down on it.
+ *
+ * Neither field is written as null when it comes back empty: a page that has
+ * dropped its OG tag this month shouldn't blank the image a previous run read
+ * off it, and a scraped handle shouldn't be cleared by a redesign that moved
+ * the footer link. Only a moved URL clears them, up in the sync itself.
+ */
+async function readSiteMetaAndUpdateDb(item: {
+  id: string;
+  websiteUrl: string;
+}) {
+  const meta = await fetchSiteMeta(item.websiteUrl);
 
-    if (ogImage?.startsWith("/")) {
-      const urlObj = new URL(url);
-      const baseUrl = urlObj.origin;
-      ogImage = `${baseUrl}${ogImage}`;
-    }
-
-    return ogImage ?? null;
-  } catch (error) {
-    console.error("Error fetching OpenGraph image for", url, error);
-    return null;
-  }
+  await db
+    .update(collectables)
+    .set({
+      ...(meta.ogImage ? { ogImageUrl: meta.ogImage } : {}),
+      ...(meta.twitterHandle ? { twitterHandle: meta.twitterHandle } : {}),
+      ogImageLastFetchedAt: new Date(),
+    })
+    .where(eq(collectables.id, item.id));
 }
 
-async function fetchOpenGraphAndUpdateDb(id: string, url: string) {
-  const ogImage = await fetchOpenGraph(url);
-  if (ogImage) {
-    await db
-      .update(collectables)
-      .set({
-        ogImageUrl: ogImage,
-        ogImageLastFetchedAt: new Date(),
-      })
-      .where(eq(collectables.id, id));
-  }
+/**
+ * Captures one row's site and records the attempt. Answers whether a cover was
+ * actually taken, which is what the run reports.
+ *
+ * A rate-limited row is left unstamped so it comes round on the next run rather
+ * than waiting out the retry window over a ceiling that had nothing to do with
+ * it — the same bargain the profile pass strikes.
+ */
+async function captureScreenshotAndUpdateDb(item: {
+  id: string;
+  websiteUrl: string;
+}): Promise<boolean> {
+  const { url, retryable } = await fetchScreenshotUrl(item.websiteUrl, {
+    // Square, to match the frame it is rendered in. A wide capture cropped to
+    // a square card loses the sides of the page; asking the browser for the
+    // shape we want composes the site's own layout for it instead.
+    width: 1200,
+    height: 1200,
+  });
+
+  if (!url && retryable) return false;
+
+  await db
+    .update(collectables)
+    .set({
+      ...(url ? { screenshotUrl: url } : {}),
+      screenshotLastFetchedAt: new Date(),
+    })
+    .where(eq(collectables.id, item.id));
+
+  return url !== null;
+}
+
+/**
+ * Mirrors one row's X avatar into Blob.
+ *
+ * Always stamped: unlike a screenshot, a miss here is nearly always a handle
+ * that does not resolve to an account, and re-asking tomorrow will not change
+ * that. The row comes back after the retry window in case the account appears.
+ */
+async function fetchAvatarAndUpdateDb(item: {
+  id: string;
+  twitterHandle: string | null;
+}): Promise<boolean> {
+  if (!item.twitterHandle) return false;
+
+  const avatarUrl = await fetchAvatarUrl(item.twitterHandle, item.id);
+
+  await db
+    .update(collectables)
+    .set({
+      ...(avatarUrl ? { avatarUrl } : {}),
+      avatarLastFetchedAt: new Date(),
+    })
+    .where(eq(collectables.id, item.id));
+
+  return avatarUrl !== null;
 }

--- a/src/app/api/notion-sync/route.ts
+++ b/src/app/api/notion-sync/route.ts
@@ -600,13 +600,7 @@ async function captureScreenshotAndUpdateDb(item: {
   id: string;
   websiteUrl: string;
 }): Promise<boolean> {
-  const { url, retryable } = await fetchScreenshotUrl(item.websiteUrl, {
-    // Square, to match the frame it is rendered in. A wide capture cropped to
-    // a square card loses the sides of the page; asking the browser for the
-    // shape we want composes the site's own layout for it instead.
-    width: 1200,
-    height: 1200,
-  });
+  const { url, retryable } = await fetchScreenshotUrl(item.websiteUrl);
 
   if (!url && retryable) return false;
 

--- a/src/components/collectable-card.tsx
+++ b/src/components/collectable-card.tsx
@@ -256,16 +256,18 @@ export function CollectableCard({ collectable }: CollectableCardProps) {
         className="relative z-0 mb-3 aspect-square overflow-hidden bg-muted"
       >
         {/* The designer's own site, then whatever artwork they published for
-            sharing, then their initials. The first fills the frame because it
-            is a picture of a page; the second is padded because it is usually a
-            logo, and blowing one up to the bleed only makes it blurry. */}
+            sharing, then their initials. The first two are drawn the same way —
+            inset, with the frame showing around them — which is the treatment
+            both grids already use. They stay separate branches only so a
+            screenshot that fails to load falls through to the OG image rather
+            than past it to the initials tile. */}
         {collectable.screenshotUrl && !screenshotError ? (
           <Image
             src={collectable.screenshotUrl}
             alt={collectable.name}
             fill
             unoptimized
-            className="object-cover object-top"
+            className="object-contain p-16"
             onError={() => setScreenshotError(true)}
           />
         ) : collectable.ogImageUrl && !ogImageError ? (

--- a/src/components/collectable-card.tsx
+++ b/src/components/collectable-card.tsx
@@ -189,9 +189,9 @@ export function CollectableCard({ collectable, terms }: CollectableCardProps) {
       <div
         className={cn(
           // Stops short of the top so the avatar, the type badge and the
-          // report button stay clear of it. Measured to the bottom of the
-          // avatar, which is the tallest of the three.
-          "absolute inset-x-0 bottom-0 top-16",
+          // report button stay clear of it. All three are the same 22px tall,
+          // so one measurement covers the row.
+          "absolute inset-x-0 bottom-0 top-12",
           "transition-transform duration-300 ease-out",
           "motion-reduce:transition-none",
           isHovered ? "translate-y-0" : "translate-y-full",
@@ -368,7 +368,7 @@ export function CollectableCard({ collectable, terms }: CollectableCardProps) {
           now shares a line with the avatar, and coordinating their positions
           across two stacking contexts is how they end up overlapping. */}
       <div className="pointer-events-none absolute left-0 top-0 z-30 aspect-square w-full">
-        <div className="absolute left-3 top-3 flex items-center gap-2">
+        <div className="absolute left-3 top-3 flex items-center gap-1.5">
           <DesignerAvatar
             name={collectable.name}
             avatarUrl={collectable.avatarUrl}

--- a/src/components/collectable-card.tsx
+++ b/src/components/collectable-card.tsx
@@ -6,6 +6,7 @@ import { HelpCircle, MapPin } from "lucide-react";
 import { type api as serverApi } from "@/trpc/server";
 import { api } from "@/trpc/react";
 import { ImagePlaceholder } from "./image-placeholder";
+import { DesignerAvatar } from "./designer-avatar";
 import { useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { badgeScaleForPointer, type CoverBox } from "@/lib/cursor-badge";
@@ -79,7 +80,10 @@ export function CollectableCard({ collectable }: CollectableCardProps) {
   const coverRef = useRef<HTMLDivElement>(null);
   const badgeRef = useRef<HTMLSpanElement>(null);
   const descriptionRef = useRef<HTMLDivElement>(null);
-  const [imageError, setImageError] = useState(false);
+  // Two flags rather than one: a screenshot that fails to load should fall
+  // through to the OG image, not all the way past it to the initials tile.
+  const [screenshotError, setScreenshotError] = useState(false);
+  const [ogImageError, setOgImageError] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [hasMoreBelow, setHasMoreBelow] = useState(false);
 
@@ -176,9 +180,10 @@ export function CollectableCard({ collectable }: CollectableCardProps) {
     <div className="absolute left-0 top-0 z-30 aspect-square w-full overflow-hidden">
       <div
         className={cn(
-          // Stops short of the top so the type badge and the report button
-          // stay clear of it.
-          "absolute inset-x-0 bottom-0 top-12",
+          // Stops short of the top so the avatar, the type badge and the
+          // report button stay clear of it. Measured to the bottom of the
+          // avatar, which is the tallest of the three.
+          "absolute inset-x-0 bottom-0 top-16",
           "transition-transform duration-300 ease-out",
           "motion-reduce:transition-none",
           isHovered ? "translate-y-0" : "translate-y-full",
@@ -250,24 +255,30 @@ export function CollectableCard({ collectable }: CollectableCardProps) {
         ref={coverRef}
         className="relative z-0 mb-3 aspect-square overflow-hidden bg-muted"
       >
-        {collectable.ogImageUrl && !imageError ? (
+        {/* The designer's own site, then whatever artwork they published for
+            sharing, then their initials. The first fills the frame because it
+            is a picture of a page; the second is padded because it is usually a
+            logo, and blowing one up to the bleed only makes it blurry. */}
+        {collectable.screenshotUrl && !screenshotError ? (
+          <Image
+            src={collectable.screenshotUrl}
+            alt={collectable.name}
+            fill
+            unoptimized
+            className="object-cover object-top"
+            onError={() => setScreenshotError(true)}
+          />
+        ) : collectable.ogImageUrl && !ogImageError ? (
           <Image
             src={collectable.ogImageUrl}
             alt={collectable.name}
             fill
             unoptimized
             className="object-contain p-16"
-            onError={() => setImageError(true)}
+            onError={() => setOgImageError(true)}
           />
         ) : (
           <ImagePlaceholder name={collectable.name} />
-        )}
-
-        {collectable.type && (
-          <span className="pointer-events-none absolute left-3 top-3 z-10 flex h-[22px] items-center rounded-full bg-foreground px-2 text-xs text-background">
-            {collectable.type.charAt(0).toUpperCase() +
-              collectable.type.slice(1)}
-          </span>
         )}
 
         {collectable.location && (
@@ -336,10 +347,30 @@ export function CollectableCard({ collectable }: CollectableCardProps) {
       )}
 
       {/* Mirrors the frame's box while living outside the frame's z-0 stacking
-          context — otherwise the button would sit under the full-card link and
-          the description panel, and be unclickable. */}
-      {collectable.websiteUrl && (
-        <div className="pointer-events-none absolute left-0 top-0 z-30 aspect-square w-full">
+          context — otherwise everything in here would sit under the full-card
+          link and the description panel, and the avatar and the report button
+          would both be unclickable.
+
+          The type badge rides along rather than staying inside the frame: it
+          now shares a line with the avatar, and coordinating their positions
+          across two stacking contexts is how they end up overlapping. */}
+      <div className="pointer-events-none absolute left-0 top-0 z-30 aspect-square w-full">
+        <div className="absolute left-3 top-3 flex items-center gap-2">
+          <DesignerAvatar
+            name={collectable.name}
+            avatarUrl={collectable.avatarUrl}
+            twitterHandle={collectable.twitterHandle}
+          />
+
+          {collectable.type && (
+            <span className="flex h-[22px] items-center rounded-full bg-foreground px-2 text-xs text-background">
+              {collectable.type.charAt(0).toUpperCase() +
+                collectable.type.slice(1)}
+            </span>
+          )}
+        </div>
+
+        {collectable.websiteUrl && (
           <Tooltip>
             <TooltipTrigger asChild>
               <button
@@ -361,8 +392,8 @@ export function CollectableCard({ collectable }: CollectableCardProps) {
               Report broken link.
             </TooltipContent>
           </Tooltip>
-        </div>
-      )}
+        )}
+      </div>
 
       {collectable.websiteUrl && (
         <span

--- a/src/components/designer-avatar.tsx
+++ b/src/components/designer-avatar.tsx
@@ -16,14 +16,20 @@ interface DesignerAvatarProps {
   className?: string;
 }
 
+// Matches the type badge's `h-[22px]`, so the avatar and the badge beside it
+// read as one row of chips rather than as a portrait with a label stuck to it.
+const SIZE_PX = 22;
+
 /**
  * The designer, in the corner of their own work.
  *
  * Their X picture where the sync found one, otherwise the same initials-on-a-
  * colour treatment the empty cover uses, so a card without an avatar still
- * reads as a card rather than as a card with a hole in it. The ring is what
- * keeps either version legible over a screenshot, which can be any colour at
- * all right where the avatar sits.
+ * reads as a card rather than as a card with a hole in it.
+ *
+ * No ring around it: the cover is drawn inset, so the corner is the frame's
+ * own flat background rather than whatever colour the screenshot happens to be
+ * at that spot, and there is nothing left to separate the avatar from.
  */
 export function DesignerAvatar({
   name,
@@ -38,25 +44,30 @@ export function DesignerAvatar({
   const circle = (
     <span
       className={cn(
-        "flex h-11 w-11 items-center justify-center overflow-hidden rounded-full",
-        "ring-2 ring-white/90",
+        "flex shrink-0 items-center justify-center overflow-hidden rounded-full",
         className,
       )}
-      style={avatarUrl && !imageError ? undefined : { backgroundColor }}
+      style={{
+        height: SIZE_PX,
+        width: SIZE_PX,
+        ...(avatarUrl && !imageError ? {} : { backgroundColor }),
+      }}
     >
       {avatarUrl && !imageError ? (
         <Image
           src={avatarUrl}
           alt={name}
-          width={44}
-          height={44}
+          width={SIZE_PX}
+          height={SIZE_PX}
           unoptimized
           className="h-full w-full object-cover"
           onError={() => setImageError(true)}
         />
       ) : (
+        // Two initials inside 22px, so the type ramps down with the circle and
+        // tightens up rather than touching the edges.
         <span
-          className="text-sm font-medium"
+          className="text-[9px] font-medium leading-none tracking-tight"
           style={{ color: inkForBackground(backgroundColor) }}
         >
           {initialsFor(name)}

--- a/src/components/designer-avatar.tsx
+++ b/src/components/designer-avatar.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+  colorForName,
+  initialsFor,
+  inkForBackground,
+} from "@/lib/name-visuals";
+
+interface DesignerAvatarProps {
+  name: string;
+  avatarUrl: string | null;
+  twitterHandle: string | null;
+  className?: string;
+}
+
+/**
+ * The designer, in the corner of their own work.
+ *
+ * Their X picture where the sync found one, otherwise the same initials-on-a-
+ * colour treatment the empty cover uses, so a card without an avatar still
+ * reads as a card rather than as a card with a hole in it. The ring is what
+ * keeps either version legible over a screenshot, which can be any colour at
+ * all right where the avatar sits.
+ */
+export function DesignerAvatar({
+  name,
+  avatarUrl,
+  twitterHandle,
+  className,
+}: DesignerAvatarProps) {
+  const [imageError, setImageError] = useState(false);
+
+  const backgroundColor = colorForName(name);
+
+  const circle = (
+    <span
+      className={cn(
+        "flex h-11 w-11 items-center justify-center overflow-hidden rounded-full",
+        "ring-2 ring-white/90",
+        className,
+      )}
+      style={avatarUrl && !imageError ? undefined : { backgroundColor }}
+    >
+      {avatarUrl && !imageError ? (
+        <Image
+          src={avatarUrl}
+          alt={name}
+          width={44}
+          height={44}
+          unoptimized
+          className="h-full w-full object-cover"
+          onError={() => setImageError(true)}
+        />
+      ) : (
+        <span
+          className="text-sm font-medium"
+          style={{ color: inkForBackground(backgroundColor) }}
+        >
+          {initialsFor(name)}
+        </span>
+      )}
+    </span>
+  );
+
+  // Rendered inside the card's pointer-events-none overlay, so the anchor has
+  // to take the pointer back for itself. Without a handle there is nothing to
+  // link to and the circle stays inert, letting the full-card link underneath
+  // have the click.
+  if (!twitterHandle) return circle;
+
+  return (
+    <a
+      href={`https://x.com/${twitterHandle}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="pointer-events-auto cursor-pointer rounded-full"
+      onClick={(event) => event.stopPropagation()}
+      aria-label={`${name} on X`}
+    >
+      {circle}
+    </a>
+  );
+}

--- a/src/components/image-placeholder.tsx
+++ b/src/components/image-placeholder.tsx
@@ -1,57 +1,17 @@
+import {
+  colorForName,
+  initialsFor,
+  inkForBackground,
+} from "@/lib/name-visuals";
+
 interface ImagePlaceholderProps {
   name: string;
   className?: string;
 }
 
-// Expanded Bauhaus and Swiss style inspired color palette
-const bauhausColors = [
-  "#E30022", // Bauhaus Red
-  "#0087CC", // Bauhaus Blue
-  "#F5D13B", // Bauhaus Yellow
-  "#000000", // Black
-  "#D9043D", // Swiss Red
-  "#005CA9", // Swiss Blue
-  "#FFDD00", // Swiss Yellow
-  "#009F4D", // Green
-  "#FF5C00", // Bauhaus Orange
-  "#7C378A", // Bauhaus Purple
-  "#00A19A", // Teal
-  "#6B6B6B", // Dark Gray
-  "#B8B8B8", // Light Gray
-  "#E84E0F", // Vermilion
-  "#2D2D2D", // Charcoal
-  "#F2F2F2", // Off-White
-  "#005F73", // Dark Teal
-  "#DC143C", // Crimson
-  "#1A5E63", // Petroleum Blue
-  "#F28C28", // Tangerine
-  "#264653", // Prussian Blue
-  "#E76F51", // Burnt Sienna
-  "#2A9D8F", // Persian Green
-  "#E9C46A", // Saffron
-];
-
 export function ImagePlaceholder({ name, className }: ImagePlaceholderProps) {
-  // Get initials from name (up to 2 characters)
-  const initials = name
-    .split(/[^a-zA-Z]/)
-    .map((word) => word[0])
-    .join("")
-    .toUpperCase()
-    .slice(0, 2);
-
-  // Generate a deterministic hash from the name to select a color
-  const nameHash = name
-    .split("")
-    .reduce((acc, char) => acc + char.charCodeAt(0), 0);
-
-  // Select a color from the palette based on the name hash
-  const backgroundColor = bauhausColors[nameHash % bauhausColors.length];
-
-  // Create solid color style
-  const colorStyle = {
-    backgroundColor: backgroundColor,
-  };
+  const initials = initialsFor(name);
+  const backgroundColor = colorForName(name);
 
   return (
     <div
@@ -63,9 +23,14 @@ export function ImagePlaceholder({ name, className }: ImagePlaceholderProps) {
       >
         <div
           className="absolute inset-0 flex items-center justify-center"
-          style={colorStyle}
+          style={{ backgroundColor }}
         >
-          <span className="text-4xl font-medium text-white">{initials}</span>
+          <span
+            className="text-4xl font-medium"
+            style={{ color: inkForBackground(backgroundColor) }}
+          >
+            {initials}
+          </span>
         </div>
       </div>
     </div>

--- a/src/env.js
+++ b/src/env.js
@@ -21,6 +21,7 @@ export const env = createEnv({
     NOTION_CASE_STUDY_DATABASE_ID: z.string().optional(),
     ANTHROPIC_API_KEY: z.string().optional(),
     BLOB_READ_WRITE_TOKEN: z.string().optional(),
+    SCREENSHOT_API_KEY: z.string().optional(),
   },
 
   /**
@@ -42,6 +43,7 @@ export const env = createEnv({
     NOTION_CASE_STUDY_DATABASE_ID: process.env.NOTION_CASE_STUDY_DATABASE_ID,
     ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
     BLOB_READ_WRITE_TOKEN: process.env.BLOB_READ_WRITE_TOKEN,
+    SCREENSHOT_API_KEY: process.env.SCREENSHOT_API_KEY,
     DATABASE_URL: process.env.DATABASE_URL,
     NODE_ENV: process.env.NODE_ENV,
     // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,

--- a/src/lib/name-visuals.ts
+++ b/src/lib/name-visuals.ts
@@ -1,0 +1,80 @@
+// Expanded Bauhaus and Swiss style inspired color palette
+const bauhausColors = [
+  "#E30022", // Bauhaus Red
+  "#0087CC", // Bauhaus Blue
+  "#F5D13B", // Bauhaus Yellow
+  "#000000", // Black
+  "#D9043D", // Swiss Red
+  "#005CA9", // Swiss Blue
+  "#FFDD00", // Swiss Yellow
+  "#009F4D", // Green
+  "#FF5C00", // Bauhaus Orange
+  "#7C378A", // Bauhaus Purple
+  "#00A19A", // Teal
+  "#6B6B6B", // Dark Gray
+  "#B8B8B8", // Light Gray
+  "#E84E0F", // Vermilion
+  "#2D2D2D", // Charcoal
+  "#F2F2F2", // Off-White
+  "#005F73", // Dark Teal
+  "#DC143C", // Crimson
+  "#1A5E63", // Petroleum Blue
+  "#F28C28", // Tangerine
+  "#264653", // Prussian Blue
+  "#E76F51", // Burnt Sienna
+  "#2A9D8F", // Persian Green
+  "#E9C46A", // Saffron
+];
+
+/**
+ * Up to two initials for a name.
+ *
+ * `filter(Boolean)` is doing real work: splitting on runs of non-letters leaves
+ * an empty string for every gap between them, so "A.B. Design" and any name
+ * with a double space would otherwise take `undefined` as its first initial.
+ * A name with no Latin letters at all yields "", which the callers draw as a
+ * plain tile rather than an empty box.
+ */
+export function initialsFor(name: string): string {
+  return name
+    .split(/[^a-zA-Z]/)
+    .filter(Boolean)
+    .map((word) => word[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+/**
+ * A stable colour for a name. Deterministic so a designer's tile is the same on
+ * every render and every machine, and shared between the square placeholder and
+ * the round avatar so one card never shows two different colours for one person.
+ */
+export function colorForName(name: string): string {
+  const nameHash = name
+    .split("")
+    .reduce((acc, char) => acc + char.charCodeAt(0), 0);
+
+  return bauhausColors[nameHash % bauhausColors.length]!;
+}
+
+/**
+ * Ink that can actually be read on `colorForName`'s answer.
+ *
+ * The palette runs from black to off-white, so the white the initials used to
+ * be painted in unconditionally disappeared on four of the twenty-four — a name
+ * landing on Off-White or Swiss Yellow drew a blank tile. Relative luminance
+ * per WCAG, with the threshold at the point where black overtakes white for
+ * contrast.
+ */
+export function inkForBackground(hex: string): "#FFFFFF" | "#1A1A1A" {
+  const channel = (offset: number) => {
+    const value = parseInt(hex.slice(offset, offset + 2), 16) / 255;
+    return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  };
+
+  const luminance =
+    0.2126 * channel(1) + 0.7152 * channel(3) + 0.0722 * channel(5);
+
+  return luminance > 0.4 ? "#1A1A1A" : "#FFFFFF";
+}

--- a/src/lib/notion-sync.ts
+++ b/src/lib/notion-sync.ts
@@ -1,5 +1,6 @@
 import { Client as NotionClient } from "@notionhq/client";
 import type { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
+import { parseTwitterHandle } from "@/lib/site-meta";
 
 export const notion = new NotionClient({
   auth: process.env.NOTION_API_KEY,
@@ -13,6 +14,13 @@ interface NotionItem {
   type: string | null;
   tags: string[];
   websiteUrl: string;
+  /**
+   * Optional hand-entered override for the handle the sync otherwise reads off
+   * the designer's site. Null both when the property is empty and when the
+   * database has no such column at all, so adding it in Notion is opt-in and
+   * its absence changes nothing.
+   */
+  twitterHandle: string | null;
 }
 
 export async function fetchNotionData(): Promise<NotionItem[]> {
@@ -44,9 +52,28 @@ export async function fetchNotionData(): Promise<NotionItem[]> {
           page.properties.url?.type === "url"
             ? (page.properties.url.url ?? "")
             : "",
+        twitterHandle: readTwitterProperty(page),
       }));
   } catch (error) {
     console.error("Error fetching Notion data:", error);
     throw error;
   }
+}
+
+/**
+ * A `twitter` property, however the owner chose to type it — a URL column for
+ * anyone pasting profile links, a text one for anyone typing handles. Anything
+ * else, or nothing, reads as null and leaves the scraped handle standing.
+ */
+function readTwitterProperty(page: PageObjectResponse): string | null {
+  const property = page.properties.twitter;
+
+  const raw =
+    property?.type === "url"
+      ? property.url
+      : property?.type === "rich_text"
+        ? (property.rich_text[0]?.plain_text ?? null)
+        : null;
+
+  return raw ? parseTwitterHandle(raw) : null;
 }

--- a/src/lib/screenshot.ts
+++ b/src/lib/screenshot.ts
@@ -20,35 +20,26 @@ export interface ScreenshotResult {
   retryable: boolean;
 }
 
-interface ScreenshotOptions {
-  /** Capture viewport, in CSS pixels. Microlink's own default when omitted. */
-  width?: number;
-  height?: number;
-}
-
 /**
  * Captures a screenshot of a page and returns a hosted image URL.
  *
  * Kept behind one helper so the provider stays swappable. Only meaningful for
  * ordinary websites — x.com and friends block automated capture, so video
  * entries use their poster frame instead of calling this.
+ *
+ * No viewport is requested: both grids draw the capture inset inside a square
+ * frame, so the page is better off rendering at the desktop width it was
+ * designed for and being letterboxed than being composed to a shape no visitor
+ * would ever see it in.
  */
 export async function fetchScreenshotUrl(
   url: string,
-  options: ScreenshotOptions = {},
 ): Promise<ScreenshotResult> {
   const endpoint = new URL("https://api.microlink.io");
   endpoint.searchParams.set("url", url);
   endpoint.searchParams.set("screenshot", "true");
   endpoint.searchParams.set("meta", "false");
   endpoint.searchParams.set("waitUntil", "networkidle2");
-
-  if (options.width !== undefined) {
-    endpoint.searchParams.set("viewport.width", String(options.width));
-  }
-  if (options.height !== undefined) {
-    endpoint.searchParams.set("viewport.height", String(options.height));
-  }
 
   const apiKey = process.env.SCREENSHOT_API_KEY;
 

--- a/src/lib/screenshot.ts
+++ b/src/lib/screenshot.ts
@@ -7,6 +7,25 @@ interface MicrolinkResponse {
   };
 }
 
+export interface ScreenshotResult {
+  url: string | null;
+  /**
+   * Whether a failure is worth coming back to. A rate limit or a dropped
+   * connection says nothing about the site and should be retried; a site that
+   * refuses capture will refuse it again tomorrow. Callers use this to decide
+   * whether to stamp the row as attempted — without the distinction a
+   * rate-limited row either burns the budget forever or waits out a month it
+   * did nothing to deserve.
+   */
+  retryable: boolean;
+}
+
+interface ScreenshotOptions {
+  /** Capture viewport, in CSS pixels. Microlink's own default when omitted. */
+  width?: number;
+  height?: number;
+}
+
 /**
  * Captures a screenshot of a page and returns a hosted image URL.
  *
@@ -14,12 +33,22 @@ interface MicrolinkResponse {
  * ordinary websites — x.com and friends block automated capture, so video
  * entries use their poster frame instead of calling this.
  */
-export async function fetchScreenshotUrl(url: string): Promise<string | null> {
+export async function fetchScreenshotUrl(
+  url: string,
+  options: ScreenshotOptions = {},
+): Promise<ScreenshotResult> {
   const endpoint = new URL("https://api.microlink.io");
   endpoint.searchParams.set("url", url);
   endpoint.searchParams.set("screenshot", "true");
   endpoint.searchParams.set("meta", "false");
   endpoint.searchParams.set("waitUntil", "networkidle2");
+
+  if (options.width !== undefined) {
+    endpoint.searchParams.set("viewport.width", String(options.width));
+  }
+  if (options.height !== undefined) {
+    endpoint.searchParams.set("viewport.height", String(options.height));
+  }
 
   const apiKey = process.env.SCREENSHOT_API_KEY;
 
@@ -30,13 +59,18 @@ export async function fetchScreenshotUrl(url: string): Promise<string | null> {
 
     if (!response.ok) {
       console.error("Screenshot request failed for", url, response.status);
-      return null;
+      // 429 is the free tier's daily ceiling rather than anything about this
+      // page; 5xx is the service having a bad minute. Both come round again.
+      return {
+        url: null,
+        retryable: response.status === 429 || response.status >= 500,
+      };
     }
 
     const body = (await response.json()) as MicrolinkResponse;
-    return body.data?.screenshot?.url ?? null;
+    return { url: body.data?.screenshot?.url ?? null, retryable: false };
   } catch (error) {
     console.error("Error fetching screenshot for", url, error);
-    return null;
+    return { url: null, retryable: true };
   }
 }

--- a/src/lib/site-meta.ts
+++ b/src/lib/site-meta.ts
@@ -1,0 +1,157 @@
+import * as cheerio from "cheerio";
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+// Some hosts refuse a request with no User-Agent outright. Naming the crawler
+// costs nothing and gets a page back from a few sites that would otherwise 403.
+const USER_AGENT = "cur8d-bot/1.0 (+https://cur8d.club)";
+
+// Paths under x.com that are actions or sections rather than people. A site's
+// "share this" button links twitter.com/intent/tweet, and taking the first
+// segment of that would file every designer on the internet under the handle
+// "intent".
+const RESERVED_TWITTER_PATHS = new Set([
+  "intent",
+  "share",
+  "home",
+  "search",
+  "hashtag",
+  "explore",
+  "messages",
+  "notifications",
+  "settings",
+  "privacy",
+  "tos",
+  "about",
+  "login",
+  "signup",
+  "i",
+]);
+
+const TWITTER_HOSTS = new Set([
+  "x.com",
+  "www.x.com",
+  "twitter.com",
+  "www.twitter.com",
+  "mobile.twitter.com",
+]);
+
+export interface SiteMeta {
+  ogImage: string | null;
+  twitterHandle: string | null;
+}
+
+/** X's own rule for what a handle may contain. */
+function isWellFormedHandle(handle: string): boolean {
+  return /^[A-Za-z0-9_]{1,15}$/.test(handle);
+}
+
+/**
+ * The handle out of anything that might carry one — a full profile URL, or the
+ * bare `@name` a `twitter:creator` tag usually holds. Null for a link that
+ * points at X but not at a person.
+ */
+export function parseTwitterHandle(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed === "") return null;
+
+  // The meta tags hold a handle rather than a URL, and are the only place a
+  // leading @ shows up.
+  if (!trimmed.includes("/")) {
+    const bare = trimmed.replace(/^@/, "");
+    return isWellFormedHandle(bare) ? bare.toLowerCase() : null;
+  }
+
+  try {
+    // Protocol-relative and bare-host hrefs are both common in footers.
+    const url = new URL(
+      trimmed.startsWith("//")
+        ? `https:${trimmed}`
+        : /^https?:\/\//i.test(trimmed)
+          ? trimmed
+          : `https://${trimmed}`,
+    );
+
+    if (!TWITTER_HOSTS.has(url.hostname.toLowerCase())) return null;
+
+    const [first] = url.pathname.split("/").filter(Boolean);
+    if (!first) return null;
+
+    const handle = first.replace(/^@/, "");
+    if (RESERVED_TWITTER_PATHS.has(handle.toLowerCase())) return null;
+
+    return isWellFormedHandle(handle) ? handle.toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reads a designer's site once and takes both things the sync wants off it.
+ *
+ * One fetch and one parse for the pair: the OG image scrape was already loading
+ * every page in the directory, and the handle is sitting in the same document.
+ */
+export async function fetchSiteMeta(url: string): Promise<SiteMeta> {
+  // A designer whose "site" is their X profile is their own answer — and the
+  // page itself is unfetchable from a data centre, so this is the only way that
+  // row ever gets a handle.
+  const handleFromOwnUrl = parseTwitterHandle(url);
+
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { "User-Agent": USER_AGENT },
+    });
+
+    if (!response.ok) {
+      return { ogImage: null, twitterHandle: handleFromOwnUrl };
+    }
+
+    const $ = cheerio.load(await response.text());
+
+    let ogImage = $('meta[property="og:image"]').attr("content");
+    if (ogImage?.startsWith("/")) {
+      ogImage = `${new URL(url).origin}${ogImage}`;
+    }
+
+    return {
+      ogImage: ogImage ?? null,
+      twitterHandle: handleFromOwnUrl ?? findTwitterHandle($),
+    };
+  } catch (error) {
+    console.error("Error fetching site meta for", url, error);
+    return { ogImage: null, twitterHandle: handleFromOwnUrl };
+  }
+}
+
+/**
+ * Best handle the page offers, in descending order of how deliberate it is.
+ *
+ * `twitter:creator` is someone stating who wrote the page, which is exactly the
+ * question; `twitter:site` is the account behind the site, usually the same
+ * person on a portfolio. Only when neither is set does this fall back to
+ * reading links, where a designer's own profile competes with every client,
+ * friend, and share button they have linked.
+ */
+function findTwitterHandle($: cheerio.CheerioAPI): string | null {
+  const metaCandidates = [
+    $('meta[name="twitter:creator"]').attr("content"),
+    $('meta[property="twitter:creator"]').attr("content"),
+    $('meta[name="twitter:site"]').attr("content"),
+    $('meta[property="twitter:site"]').attr("content"),
+  ];
+
+  for (const candidate of metaCandidates) {
+    const handle = candidate ? parseTwitterHandle(candidate) : null;
+    if (handle) return handle;
+  }
+
+  for (const element of $("a[href]").toArray()) {
+    const href = $(element).attr("href");
+    const handle = href ? parseTwitterHandle(href) : null;
+    if (handle) return handle;
+  }
+
+  return null;
+}

--- a/src/lib/twitter-avatar.ts
+++ b/src/lib/twitter-avatar.ts
@@ -1,0 +1,26 @@
+import { mirrorToBlob } from "@/lib/blob-storage";
+
+/**
+ * Resolves a handle to a profile picture and mirrors it into Blob.
+ *
+ * Goes through unavatar rather than X directly: x.com blocks data-centre
+ * traffic, which is the same reason the profile scraper and the screenshot
+ * service both give up on it. `fallback=false` makes unavatar 404 for a handle
+ * it cannot resolve — its default is to invent a generated image, and a made-up
+ * avatar stored as a real one is worse than none, since nothing downstream
+ * could tell the difference.
+ *
+ * The bytes are copied rather than linked because twimg URLs rot, and because
+ * pointing every card at unavatar would put someone else's rate limit between
+ * the grid and its own faces.
+ */
+export async function fetchAvatarUrl(
+  handle: string,
+  id: string,
+): Promise<string | null> {
+  const source = `https://unavatar.io/x/${encodeURIComponent(
+    handle,
+  )}?fallback=false`;
+
+  return mirrorToBlob(source, `designers/${id}/avatar`);
+}

--- a/src/server/api/routers/collectable.ts
+++ b/src/server/api/routers/collectable.ts
@@ -2,14 +2,7 @@ import { z } from "zod";
 
 import { createTRPCRouter, publicProcedure } from "@/server/api/trpc";
 import { collectables } from "@/server/db/schema";
-import {
-  eq,
-  and,
-  sql,
-  arrayOverlaps,
-  asc,
-  desc,
-} from "drizzle-orm";
+import { eq, and, sql, arrayOverlaps, asc, desc } from "drizzle-orm";
 import { DEFAULT_SORT, SORT_VALUES, type SortValue } from "@/lib/sort-options";
 
 const COLLECTABLE_PER_PAGE = 12;
@@ -72,7 +65,10 @@ export const collectableRouter = createTRPCRouter({
           tags: collectables.tags,
           createdAt: collectables.createdAt,
           websiteUrl: collectables.websiteUrl,
+          screenshotUrl: collectables.screenshotUrl,
           ogImageUrl: collectables.ogImageUrl,
+          avatarUrl: collectables.avatarUrl,
+          twitterHandle: collectables.twitterHandle,
           aiDescription: collectables.aiDescription,
           location: collectables.location,
           company: collectables.company,

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -29,7 +29,30 @@ export const collectables = createTable(
     tags: text("tags").array(),
     websiteUrl: text("website_url").notNull(),
     ogImageUrl: text("og_image_url"),
+    // Stamped on every meta pass, found or not — the column name predates the
+    // pass reading anything besides the OG image. It now records when the site
+    // was last read for both that and the handle below, which is what keeps a
+    // site that yields neither from being re-fetched on every single run.
     ogImageLastFetchedAt: timestamp("og_image_last_fetched_at", {
+      withTimezone: true,
+    }),
+
+    // Screenshot of the designer's own site, and the card's cover. `ogImageUrl`
+    // stays behind it as the fallback: capture is rate-limited and plenty of
+    // sites refuse it outright, so a good many rows will never have one.
+    screenshotUrl: text("screenshot_url"),
+    screenshotLastFetchedAt: timestamp("screenshot_last_fetched_at", {
+      withTimezone: true,
+    }),
+
+    // The designer's X handle, without the @, read off their own site during
+    // the meta pass. Null is the common case and not a failure — most sites
+    // never link a profile.
+    twitterHandle: text("twitter_handle"),
+    // Their X avatar, mirrored into Blob rather than linked: twimg URLs rot the
+    // same way Notion's do, which is why `blob-storage.ts` exists.
+    avatarUrl: text("avatar_url"),
+    avatarLastFetchedAt: timestamp("avatar_last_fetched_at", {
       withTimezone: true,
     }),
 


### PR DESCRIPTION
## Summary

This PR extends the Notion sync pipeline to capture three new pieces of designer information: site screenshots (for card covers), Twitter/X handles (scraped from designer sites), and Twitter avatar images. It introduces a new `withBackfill` abstraction to manage per-run budgets across multiple data-fetching passes, and refactors color/initials logic into a shared utility.

## ⚠️ Database changes — run this SQL **before** merging

Per `CLAUDE.md`, the SQL that puts a `schema.ts` change into the database ships with the change:

```sql
ALTER TABLE cur8d_collectable
  ADD COLUMN IF NOT EXISTS screenshot_url text,
  ADD COLUMN IF NOT EXISTS screenshot_last_fetched_at timestamp with time zone,
  ADD COLUMN IF NOT EXISTS twitter_handle text,
  ADD COLUMN IF NOT EXISTS avatar_url text,
  ADD COLUMN IF NOT EXISTS avatar_last_fetched_at timestamp with time zone;
```

**Order matters — the SQL must run first, not "either order".** Every column is nullable, which means old code tolerates a database that *has* them. It does not mean new code tolerates a database that *lacks* them. Deployed ahead of the SQL, this code fails on any query naming the new columns:

- `getInfiniteScroll` lists them explicitly in `selectDistinct`
- `getLatest` and the three sync queries use a bare `findMany()`, which drizzle expands to every column in `schema.ts`

`getInfiniteScroll` is what server-renders the home page, so the designer grid — the default view — would 500 until the SQL was run. (`getUniqueTags` / `getUniqueTypes` survive only because they pass an explicit `columns:` filter.)

Run the SQL first and there is no window at all: the old code ignores the new columns completely.

**Checked against a local Postgres 16:** built the table at the previous schema, applied the SQL, confirmed a seeded row kept its values with the new columns null, ran the SQL a second time to confirm it is a no-op, and confirmed `drizzle-kit push` then reports "No changes detected" against the new `schema.ts`.

**Note on the preview deployment:** if this project's Preview environment shares the production `DATABASE_URL`, this PR's preview URL will 500 on the designer grid until the SQL is run. Nothing can be corrupted — `vercel.json` only schedules crons, and Vercel runs those on production deployments, not previews.

## Key Changes

- **New data fetching passes**: Added three new sync passes with independent budgets:
  - `readSiteMetaAndUpdateDb`: Reads OG images and scrapes Twitter handles from designer sites
  - `captureScreenshotAndUpdateDb`: Captures site screenshots as primary card covers
  - `fetchAvatarAndUpdateDb`: Mirrors Twitter avatars into Blob storage

- **Unified backfill logic**: Introduced `withBackfill()` helper to manage per-run budgets consistently across all passes. Priority items (newly added or URL-changed rows) are processed first, then remaining budget fills with longest-neglected rows.

- **Database schema extensions**: Added columns for `screenshotUrl`, `screenshotLastFetchedAt`, `twitterHandle`, `avatarUrl`, and `avatarLastFetchedAt` with appropriate retry windows (30 days).

- **Site metadata extraction** (`src/lib/site-meta.ts`): New module that:
  - Fetches and parses a designer&#39;s site in one pass
  - Extracts OG image URLs (with relative path resolution)
  - Intelligently scrapes Twitter handles from meta tags and links
  - Includes `parseTwitterHandle()` to validate and normalize handles against X&#39;s rules

- **Avatar component** (`src/components/designer-avatar.tsx`): New component that displays:
  - Twitter avatar image when available
  - Falls back to initials-on-color tile matching the empty cover style
  - Links to designer&#39;s X profile when handle is present
  - Sits in the frame's top-left corner, on the padding beside the type badge

- **Shared name visuals** (`src/lib/name-visuals.ts`): Extracted color/initials logic from `ImagePlaceholder` into reusable utilities:
  - `colorForName()`: Deterministic color selection from Bauhaus palette
  - `initialsFor()`: Extracts up to 2 initials from names
  - `inkForBackground()`: WCAG-based contrast calculation for text color

- **Card cover hierarchy**: Updated `CollectableCard` to prioritize covers:
  1. Screenshot (if available)
  2. OG image (fallback)
  3. Initials tile (final fallback)

  The first two are drawn identically — `object-contain p-16`, inset with the frame showing around them — which is the treatment the projects tab and the existing OG-image covers already use. They remain separate branches with independent error flags purely so a screenshot that fails to load falls through to the OG image rather than past it to the initials tile.

- **Notion integration**: Extended `fetchNotionData()` to read optional `twitterHandle` property, allowing manual overrides of scraped handles.

## Notable Implementation Details

- **Stamping on every attempt**: The meta pass stamps its timestamp even when the page yields nothing, which fixes an existing bug — it previously stamped only on success, so a site with no OG image was re-fetched on every single run, forever. The screenshot pass stamps on success and on non-retryable failure. Only moved URLs clear these fields.
- **Rate limit handling**: Screenshot pass distinguishes retryable failures (rate limits, timeouts) from permanent ones (site refuses capture), leaving retryable rows unstamped to retry sooner.
- **Handle precedence**: Notion&#39;s hand-entered handle overrides scraped values, but only when explicitly set (empty cells don&#39;t wipe found handles).
- **URL-moved cleanup**: When a designer&#39;s URL changes, screenshots/handles/avatars are cleared (unlike profile descriptions which may still be accurate), but OG images are preserved as they may still be relevant.
- **Fetch timeout**: Site meta fetches use 10-second timeout with User-Agent header to improve success rates.
- **Reserved Twitter paths**: Filters out X system paths (intent, share, home, etc.) to avoid filing designers under action endpoints.
- **`SCREENSHOT_API_KEY`** was read by `screenshot.ts` but declared in neither `env.js` nor `.env.example`, which `.env.example` explicitly says not to do. This change makes the designer grid depend on it, so it is declared now.

## Verification

- `npm run check` clean (lint + `tsc --noEmit`)
- Migration verified against a local Postgres 16 (see above)
- `parseTwitterHandle` — 24/24 cases: profile URLs in the shapes footers use (protocol-relative, bare-host, `mobile.twitter.com`), meta-tag `@handle` values, and rejection of `intent/tweet`, `/share`, `/i/flow/login`, `/hashtag`, non-X hosts, malformed input
- `fetchSiteMeta` — 5/5 against local HTML fixtures: root-relative `og:image` resolved to origin, `twitter:creator` beating a share link in the body, first *valid* profile link when no meta tag exists, `twitter:site` fallback, graceful nulls on a bare page and a 404
- Grid rendered across all cover/avatar combinations plus the hover state; hit-testing confirmed the avatar link wins the click over the card-wide link when a handle exists and passes through when it doesn't
- Projects tab confirmed unchanged

**Not verified:** the sandbox's egress proxy blocks microlink, unavatar, and arbitrary designer sites, so the live capture and avatar calls could not be exercised end to end — only the logic around them.

## Rollout

At 20 screenshots per daily cron the directory fills in over a couple of weeks. `?screenshots=N` (to 100) sweeps by hand, and `?meta=` / `?avatars=` do the same for the other two passes. Without `SCREENSHOT_API_KEY` most captures in a large sweep come back rate-limited — those rows stay unstamped and retry, so nothing is lost, but it is worth setting the key before the first sweep.

https://claude.ai/code/session_01DuxwwXSMaDuL56U3YxfV6p