### PR TITLE
Adjust collectable card image inset padding

### DIFF
--- a/src/components/collectable-card.tsx
+++ b/src/components/collectable-card.tsx
@@ -265,8 +265,9 @@ export function CollectableCard({ collectable, terms }: CollectableCardProps) {
       >
         {/* The designer's own site, then whatever artwork they published for
             sharing, then their initials. The first two are drawn the same way —
-            inset, with the frame showing around them — which is the treatment
-            both grids already use. They stay separate branches only so a
+            inset, with the frame showing around them — on a 36px inset, tighter
+            than the case study grid's, so the artwork carries the tile and the
+            frame reads as a border. They stay separate branches only so a
             screenshot that fails to load falls through to the OG image rather
             than past it to the initials tile. */}
         {collectable.screenshotUrl && !screenshotError ? (
@@ -275,7 +276,7 @@ export function CollectableCard({ collectable, terms }: CollectableCardProps) {
             alt={collectable.name}
             fill
             unoptimized
-            className="object-contain p-16"
+            className="object-contain p-9"
             onError={() => setScreenshotError(true)}
           />
         ) : collectable.ogImageUrl && !ogImageError ? (
@@ -284,7 +285,7 @@ export function CollectableCard({ collectable, terms }: CollectableCardProps) {
             alt={collectable.name}
             fill
             unoptimized
-            className="object-contain p-16"
+            className="object-contain p-9"
             onError={() => setOgImageError(true)}
           />
         ) : (


### PR DESCRIPTION
## Summary
Updated the image inset padding on collectable cards to create a tighter, more visually balanced layout where the artwork carries the tile and the frame reads as a border.

## Changes
- Reduced image padding from `p-16` to `p-9` (36px to 18px inset) for both screenshot and OG image fallback
- Updated the component comment to clarify the new design intent: the tighter inset makes the artwork more prominent while the frame functions as a border, differentiating it from the case study grid's treatment

## Details
The padding adjustment applies to both image fallback branches:
- Screenshot image (primary)
- OG image (fallback when screenshot fails to load)

This creates a more cohesive visual hierarchy where the artwork takes precedence in the tile composition.

https://claude.ai/code/session_01PWHASdiptSouqYUwWvj9vj