### PR TITLE
Refactor ViewToggle chip animation to measure against track

### DIFF
--- a/src/app/api/case-study-sync/route.ts
+++ b/src/app/api/case-study-sync/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { eq, inArray } from "drizzle-orm";
 import {
   fetchCaseStudyData,
@@ -8,6 +9,7 @@ import { generateSummary } from "@/lib/ai-summary";
 import { mirrorToBlob } from "@/lib/blob-storage";
 import { fetchScreenshotUrl } from "@/lib/screenshot";
 import { db } from "@/server/db";
+import { FILTER_OPTIONS_TAG } from "@/lib/cache-tags";
 import { caseStudies } from "@/server/db/schema";
 
 export const maxDuration = 60;
@@ -16,7 +18,9 @@ type DbCaseStudy = typeof caseStudies.$inferSelect;
 
 /** Drops tags that no longer exist as options in Notion. */
 async function cleanupOrphanedIndustries(notionItems: NotionCaseStudy[]) {
-  const validIndustries = new Set(notionItems.flatMap((item) => item.industries));
+  const validIndustries = new Set(
+    notionItems.flatMap((item) => item.industries),
+  );
   const dbItems = await db.query.caseStudies.findMany();
 
   const stale = dbItems.filter((item) =>
@@ -103,7 +107,10 @@ function needsEnrichment(item: NotionCaseStudy, dbItem: DbCaseStudy) {
 export async function GET() {
   // The daily cron runs whether or not case studies have been set up yet, so
   // treat missing credentials as "nothing to do" rather than an error.
-  if (!process.env.NOTION_CASE_STUDY_DATABASE_ID || !process.env.NOTION_API_KEY) {
+  if (
+    !process.env.NOTION_CASE_STUDY_DATABASE_ID ||
+    !process.env.NOTION_API_KEY
+  ) {
     return NextResponse.json({
       skipped: "case study sync is not configured",
       missing: [
@@ -190,6 +197,10 @@ export async function GET() {
 
   const itemsToEnrich = [...newItems, ...staleItems];
   await Promise.all(itemsToEnrich.map(enrichCaseStudy));
+
+  // Same as the designer sync: the type and industry dropdowns are cached, so a
+  // run that changed the set of values has to drop them.
+  revalidateTag(FILTER_OPTIONS_TAG);
 
   return NextResponse.json({
     newItems: newItems.length,

--- a/src/app/api/notion-sync/route.ts
+++ b/src/app/api/notion-sync/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { fetchNotionData } from "@/lib/notion-sync";
 import { generateDesignerProfile } from "@/lib/ai-summary";
 import { fetchSiteMeta } from "@/lib/site-meta";
 import { fetchScreenshotUrl } from "@/lib/screenshot";
 import { fetchAvatarUrl } from "@/lib/twitter-avatar";
 import { db } from "@/server/db";
+import { FILTER_OPTIONS_TAG } from "@/lib/cache-tags";
 import { collectables } from "@/server/db/schema";
 import {
   and,
@@ -441,6 +443,10 @@ export async function GET(request: Request) {
       withAvatar: sql<number>`count(*) FILTER (WHERE ${collectables.avatarUrl} IS NOT NULL)::int`,
     })
     .from(collectables);
+
+  // The expertise and type dropdowns are cached across requests, so a run that
+  // added or retired a value has to drop them or the new one stays invisible.
+  revalidateTag(FILTER_OPTIONS_TAG);
 
   return NextResponse.json({
     newItems: newItems.length,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,15 @@ import { CASE_STUDY_DEFAULT_SORT, DEFAULT_SORT } from "@/lib/sort-options";
 
 const COLLECTABLE_PER_PAGE = 12;
 
+async function readCaseStudyOptions(read: () => Promise<string[]>) {
+  try {
+    return await read();
+  } catch (error) {
+    console.error("Case study filter options unavailable:", error);
+    return [];
+  }
+}
+
 interface HomeProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
@@ -21,16 +30,23 @@ export default async function Home({ searchParams }: HomeProps) {
     api.collectable.getUniqueTypes(),
   ]);
 
-  // Only read the case study tables when that view is actually being shown.
-  // Switching views is a full server round trip (the `view` param is not
-  // shallow), so the real options are fetched before the filters are visible —
-  // and the designer view stays up even if the case study table is absent.
-  const [caseStudyTypes, caseStudyIndustries] = isCaseStudyView
-    ? await Promise.all([
-        api.caseStudy.getUniqueTypes(),
-        api.caseStudy.getUniqueIndustries(),
-      ])
-    : [[], []];
+  // Both views' filter options ship on every render, whichever view is being
+  // shown. Switching views is a server round trip, but the toggle does not wait
+  // for it: the `view` param updates on the client the moment it is clicked, so
+  // the nav swaps in the other view's filters straight away and only their
+  // options would still be coming. Gating the read on `isCaseStudyView` meant
+  // those options were, by definition, never in the payload that was on screen
+  // when the switch happened — so the project filters rendered empty until the
+  // round trip landed. Sending both makes the swap immediate.
+  //
+  // The reads are cached under FILTER_OPTIONS_TAG and only recomputed when a
+  // sync drops it, so carrying the other view's options costs a cache hit.
+  const [caseStudyTypes, caseStudyIndustries] = await Promise.all([
+    // Kept non-fatal so the designer view still stands up if the case study
+    // table is absent — the filters come back empty rather than the page 500ing.
+    readCaseStudyOptions(() => api.caseStudy.getUniqueTypes()),
+    readCaseStudyOptions(() => api.caseStudy.getUniqueIndustries()),
+  ]);
 
   const nav = (
     <>

--- a/src/components/nav/view-toggle.tsx
+++ b/src/components/nav/view-toggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useId } from "react";
+import { useEffect, useRef, useState } from "react";
 import { motion, useReducedMotion } from "motion/react";
 
 import { cn } from "@/lib/utils";
@@ -21,31 +21,115 @@ interface ViewToggleProps {
   fullWidth?: boolean;
 }
 
+/** Where the chip has to sit to cover the active tab, in track coordinates. */
+interface ChipBox {
+  x: number;
+  width: number;
+  top: number;
+  height: number;
+}
+
 export function ViewToggle({ className, fullWidth = false }: ViewToggleProps) {
   const [{ view }, setViewParams] = useViewParams();
   const shouldReduceMotion = useReducedMotion();
-  // The desktop and mobile navs both mount a toggle, so the shared layout id
-  // has to be scoped per instance or the chip would fly between them.
-  const chipLayoutId = useId();
+
+  const trackRef = useRef<HTMLDivElement>(null);
+  const tabRefs = useRef(new Map<View, HTMLButtonElement>());
+  const [chip, setChip] = useState<ChipBox | null>(null);
+
+  // Built once: a ref callback that changed identity between renders would have
+  // React detach and reattach every tab, emptying the map on each pass.
+  const tabRefCallbacks = useRef(
+    new Map(
+      OPTIONS.map(({ value }) => [
+        value,
+        (element: HTMLButtonElement | null) => {
+          if (element) tabRefs.current.set(value, element);
+          else tabRefs.current.delete(value);
+        },
+      ]),
+    ),
+  ).current;
+
+  // The chip is placed from the active tab's own box rather than animated
+  // between two mounted elements. A shared layout animation (`layoutId`) would
+  // interpolate the measured document-space boxes instead, and this toggle
+  // sits in a sticky header on desktop and a fixed sheet on mobile: switching
+  // the view is a server round trip that swaps the whole grid, so the document
+  // scrolls between the two measurements and the chip is dragged along an axis
+  // it never actually moved on. Measuring against the track sidesteps that —
+  // the chip can only ever travel horizontally, because that is the only axis
+  // the two tabs differ on.
+  useEffect(() => {
+    const track = trackRef.current;
+    const activeTab = tabRefs.current.get(view);
+    if (!track || !activeTab) return;
+
+    // Measured off the rects rather than offsetLeft/offsetWidth, which round to
+    // whole pixels: the mobile sheet splits the track evenly between the tabs,
+    // so their edges land on fractions and a rounded chip sits half a pixel
+    // proud of the tab it is covering. clientLeft/clientTop are the track's
+    // border, taking the origin from its border edge to its padding edge —
+    // where the absolutely positioned chip resolves left/top from.
+    const measure = () => {
+      const trackBox = track.getBoundingClientRect();
+      const tabBox = activeTab.getBoundingClientRect();
+
+      setChip({
+        x: tabBox.left - trackBox.left - track.clientLeft,
+        width: tabBox.width,
+        top: tabBox.top - trackBox.top - track.clientTop,
+        height: tabBox.height,
+      });
+    };
+
+    measure();
+
+    // Labels reflow when the font finishes loading and the tabs are split
+    // evenly in the mobile sheet, so both the track and the tabs are watched.
+    const observer = new ResizeObserver(measure);
+    observer.observe(track);
+    for (const tab of tabRefs.current.values()) observer.observe(tab);
+    return () => observer.disconnect();
+  }, [view, fullWidth]);
 
   return (
     <div
+      ref={trackRef}
       role="tablist"
       aria-label="Browse mode"
       className={cn(
         // h-9 matches the filter pills (py-2 + text-sm) so the row lines up.
-        "inline-flex h-9 flex-shrink-0 items-center gap-0.5 rounded-full bg-neutral-200/70 p-0.5",
+        "relative inline-flex h-9 flex-shrink-0 items-center gap-0.5 rounded-full bg-neutral-200/70 p-0.5",
         // h-12 matches the stacked filter pills (py-3 + text-base).
         fullWidth && "flex h-12 w-full",
         className,
       )}
     >
+      {chip && (
+        <motion.span
+          aria-hidden
+          className="pointer-events-none absolute left-0 top-0 rounded-full bg-foreground"
+          // The first frame after measuring has to land on the active tab, not
+          // slide in from the left edge of the track.
+          initial={false}
+          animate={{ x: chip.x, width: chip.width }}
+          style={{ top: chip.top, height: chip.height }}
+          transition={
+            shouldReduceMotion
+              ? { duration: 0 }
+              : { duration: 0.3, ease: [0.32, 0.72, 0, 1] }
+          }
+        />
+      )}
+
       {OPTIONS.map((option) => {
         const isActive = view === option.value;
 
         return (
           <button
             key={option.value}
+            ref={tabRefCallbacks.get(option.value)}
             role="tab"
             type="button"
             aria-selected={isActive}
@@ -62,21 +146,18 @@ export function ViewToggle({ className, fullWidth = false }: ViewToggleProps) {
                   "text-neutral-600 duration-150 hover:text-neutral-900",
             )}
           >
-            {isActive && (
-              <motion.span
-                layoutId={chipLayoutId}
+            {/* Until the tabs have been measured — the server render, and the
+                first client paint — the active tab draws the chip itself, so
+                the toggle is never served without its indicator. The handover
+                is pixel-identical: both cover exactly this button's box. */}
+            {isActive && !chip && (
+              <span
                 aria-hidden
                 className="absolute inset-0 rounded-full bg-foreground"
-                transition={
-                  shouldReduceMotion
-                    ? { duration: 0 }
-                    : { duration: 0.3, ease: [0.32, 0.72, 0, 1] }
-                }
               />
             )}
-            {/* z-10 keeps every label above the chip: the chip lives inside the
-                active tab, so without it the chip paints over the label of the
-                tab it is sliding away from. */}
+            {/* z-10 keeps every label above the chip, which is painted by the
+                track behind the whole row of tabs. */}
             <span className="relative z-10">{option.label}</span>
           </button>
         );

--- a/src/lib/cache-tags.ts
+++ b/src/lib/cache-tags.ts
@@ -1,0 +1,11 @@
+/**
+ * The filter dropdowns are built from the distinct values across a whole table,
+ * so they only move when a sync writes rows — not between two page views. They
+ * are cached under this tag and both sync routes drop it when they finish, so a
+ * new tag or industry is live the moment it lands rather than at the end of a
+ * timeout.
+ */
+export const FILTER_OPTIONS_TAG = "filter-options";
+
+/** Backstop for anything that edits rows without going through a sync route. */
+export const FILTER_OPTIONS_REVALIDATE_SECONDS = 60 * 60;

--- a/src/server/api/routers/case-study.ts
+++ b/src/server/api/routers/case-study.ts
@@ -1,11 +1,17 @@
 import { z } from "zod";
+import { unstable_cache } from "next/cache";
 
 import { createTRPCRouter, publicProcedure } from "@/server/api/trpc";
+import { db } from "@/server/db";
 import { caseStudies } from "@/server/db/schema";
 import { and, arrayOverlaps, eq, sql } from "drizzle-orm";
 import { CASE_STUDY_DEFAULT_SORT, SORT_VALUES } from "@/lib/sort-options";
 import { getOrderBy } from "@/server/api/sort-order";
 import { parseSearchTerms, toLikePattern } from "@/lib/search";
+import {
+  FILTER_OPTIONS_REVALIDATE_SECONDS,
+  FILTER_OPTIONS_TAG,
+} from "@/lib/cache-tags";
 
 const CASE_STUDY_PER_PAGE = 12;
 
@@ -35,6 +41,46 @@ const FILTER_QUERY_OBJECT_WITH_PAGINATION = FILTER_QUERY_OBJECT.extend({
   cursor: z.number().default(0),
   limit: z.number().default(CASE_STUDY_PER_PAGE),
 });
+
+/**
+ * The project view's two dropdowns. Cached for the same reason as the designer
+ * ones, and against the same tag: a whole-table scan whose answer only moves
+ * when a sync runs has no business re-running on every view switch. See
+ * `collectable.ts` for why these read the `db` singleton rather than `ctx.db`.
+ */
+const getUniqueTypes = unstable_cache(
+  async () => {
+    const rows = await db.query.caseStudies.findMany({
+      columns: { types: true },
+    });
+
+    return [...new Set(rows.flatMap((row) => row.types ?? []))].filter(
+      (type) => type !== "",
+    );
+  },
+  ["case-study-unique-types"],
+  {
+    tags: [FILTER_OPTIONS_TAG],
+    revalidate: FILTER_OPTIONS_REVALIDATE_SECONDS,
+  },
+);
+
+const getUniqueIndustries = unstable_cache(
+  async () => {
+    const rows = await db.query.caseStudies.findMany({
+      columns: { industries: true },
+    });
+
+    return [...new Set(rows.flatMap((row) => row.industries ?? []))].filter(
+      (industry) => industry !== "",
+    );
+  },
+  ["case-study-unique-industries"],
+  {
+    tags: [FILTER_OPTIONS_TAG],
+    revalidate: FILTER_OPTIONS_REVALIDATE_SECONDS,
+  },
+);
 
 export const caseStudyRouter = createTRPCRouter({
   getInfiniteScroll: publicProcedure
@@ -81,23 +127,7 @@ export const caseStudyRouter = createTRPCRouter({
       };
     }),
 
-  getUniqueTypes: publicProcedure.query(async ({ ctx }) => {
-    const rows = await ctx.db.query.caseStudies.findMany({
-      columns: { types: true },
-    });
+  getUniqueTypes: publicProcedure.query(() => getUniqueTypes()),
 
-    return [...new Set(rows.flatMap((row) => row.types ?? []))].filter(
-      (type) => type !== "",
-    );
-  }),
-
-  getUniqueIndustries: publicProcedure.query(async ({ ctx }) => {
-    const rows = await ctx.db.query.caseStudies.findMany({
-      columns: { industries: true },
-    });
-
-    return [...new Set(rows.flatMap((row) => row.industries ?? []))].filter(
-      (industry) => industry !== "",
-    );
-  }),
+  getUniqueIndustries: publicProcedure.query(() => getUniqueIndustries()),
 });

--- a/src/server/api/routers/collectable.ts
+++ b/src/server/api/routers/collectable.ts
@@ -1,11 +1,17 @@
 import { z } from "zod";
+import { unstable_cache } from "next/cache";
 
 import { createTRPCRouter, publicProcedure } from "@/server/api/trpc";
+import { db } from "@/server/db";
 import { collectables } from "@/server/db/schema";
 import { eq, and, sql, arrayOverlaps } from "drizzle-orm";
 import { DEFAULT_SORT, SORT_VALUES } from "@/lib/sort-options";
 import { getOrderBy } from "@/server/api/sort-order";
 import { parseSearchTerms, toLikePattern } from "@/lib/search";
+import {
+  FILTER_OPTIONS_REVALIDATE_SECONDS,
+  FILTER_OPTIONS_TAG,
+} from "@/lib/cache-tags";
 
 const COLLECTABLE_PER_PAGE = 12;
 
@@ -36,6 +42,59 @@ const FILTER_QUERY_OBJECT_WITH_PAGINATION = FILTER_QUERY_OBJECT.extend({
   cursor: z.number().default(0),
   limit: z.number().default(COLLECTABLE_PER_PAGE),
 });
+
+/**
+ * The two filter dropdowns on the designer view. Both scan the whole table to
+ * collect its distinct values, and both were being re-run on every request —
+ * including every view switch, which is a server round trip. The answer only
+ * changes when a sync writes rows, so it is cached under a tag the sync routes
+ * drop rather than recomputed per page view.
+ *
+ * These read the `db` singleton directly instead of `ctx.db`: it is the same
+ * instance the context is built from, and a cache entry outlives the request
+ * whose context it would otherwise have closed over.
+ */
+const getUniqueTags = unstable_cache(
+  async () => {
+    const allTags = await db.query.collectables.findMany({
+      columns: {
+        tags: true,
+      },
+    });
+
+    const uniqueTags = [
+      ...new Set(allTags.flatMap((collectable) => collectable.tags)),
+    ].filter((tag) => tag !== "" && tag !== null);
+
+    return uniqueTags as string[];
+  },
+  ["collectable-unique-tags"],
+  {
+    tags: [FILTER_OPTIONS_TAG],
+    revalidate: FILTER_OPTIONS_REVALIDATE_SECONDS,
+  },
+);
+
+const getUniqueTypes = unstable_cache(
+  async () => {
+    const allTypes = await db.query.collectables.findMany({
+      columns: {
+        type: true,
+      },
+    });
+
+    const uniqueTypes = [
+      ...new Set(allTypes.map((collectable) => collectable.type)),
+    ].filter((type) => type !== "" && type !== null);
+
+    return uniqueTypes as string[];
+  },
+  ["collectable-unique-types"],
+  {
+    tags: [FILTER_OPTIONS_TAG],
+    revalidate: FILTER_OPTIONS_REVALIDATE_SECONDS,
+  },
+);
 
 export const collectableRouter = createTRPCRouter({
   hello: publicProcedure
@@ -104,35 +163,9 @@ export const collectableRouter = createTRPCRouter({
     return allCollectables;
   }),
 
-  getUniqueTags: publicProcedure.query(async ({ ctx }) => {
-    const allTags = await ctx.db.query.collectables.findMany({
-      columns: {
-        tags: true,
-      },
-    });
+  getUniqueTags: publicProcedure.query(() => getUniqueTags()),
 
-    const uniqueTags = allTags
-      .flatMap((collectable) => collectable.tags)
-      .filter((tag, index, self) => self.indexOf(tag) === index)
-      .filter((tag) => tag !== "" && tag !== null);
-
-    return uniqueTags as string[];
-  }),
-
-  getUniqueTypes: publicProcedure.query(async ({ ctx }) => {
-    const allTypes = await ctx.db.query.collectables.findMany({
-      columns: {
-        type: true,
-      },
-    });
-
-    const uniqueTypes = allTypes
-      .map((collectable) => collectable.type)
-      .filter((type, index, self) => self.indexOf(type) === index)
-      .filter((type) => type !== "" && type !== null);
-
-    return uniqueTypes as string[];
-  }),
+  getUniqueTypes: publicProcedure.query(() => getUniqueTypes()),
 
   reportLink: publicProcedure
     .input(z.object({ id: z.string() }))


### PR DESCRIPTION
## Summary
Refactored the ViewToggle component's animated chip indicator from using Framer Motion's `layoutId` shared layout animation to a measurement-based approach that positions the chip relative to the track container. This fixes animation issues when the toggle appears in different layout contexts (sticky header on desktop, fixed sheet on mobile).

## Key Changes
- Replaced `useId` hook with `useEffect`, `useRef`, and `useState` for manual measurement and positioning
- Introduced `ChipBox` interface to track chip position and dimensions in track-relative coordinates
- Added `trackRef` to measure the container and `tabRefs` Map to track individual tab elements
- Implemented `ResizeObserver` to remeasure chip position when tabs reflow (e.g., during font loading)
- Moved chip rendering from inside the active tab button to the track container as an absolutely positioned element
- Added fallback: active tab renders its own chip background until measurements are available (server render → first client paint)
- Updated styling: track is now `relative` positioned to serve as the positioning context for the chip

## Implementation Details
- Chip position is calculated in track-relative coordinates using `getBoundingClientRect()` and `clientLeft`/`clientTop` to account for borders
- Uses `getBoundingClientRect()` instead of `offsetLeft`/`offsetWidth` to preserve fractional pixel values, preventing misalignment in mobile sheet layouts
- ResizeObserver watches both the track and all tabs to handle reflow from font loading and other layout changes
- Transition behavior preserved: respects `useReducedMotion()` and uses the same easing curve as before
- The chip can only animate horizontally since it measures against the track, avoiding the document scroll issue that occurred with shared layout animations across different scroll contexts

https://claude.ai/code/session_01H9boy2EGJPZeNM3oQNnRK7