### PR TITLE
Let the page width track the window, capped at 1600

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -57,9 +57,17 @@ export default async function Home({ searchParams }: HomeProps) {
   // rather than under them, the way it did when they were pinned corners.
   //
   // Mobile keeps its fixed top bar and filter sheet, so the rail is md and up.
+  //
+  // Deliberately not Tailwind's `container`, which snaps its max-width to a
+  // fixed value per breakpoint — 640, 768, 1024, 1280, 1536 — and so leaves
+  // every width in between on the floor: at a 1000px window the page was
+  // locked to 768 and a quarter of the screen sat empty. A plain max-width
+  // lets the whole shell track the window, so the cards resize as it is
+  // dragged, and settles at 1600 (gutters included) rather than growing
+  // without end on a very wide screen.
   const shell = (grid: React.ReactNode) => (
     <>
-      <div className="container mx-auto px-4 md:flex md:gap-6 md:px-6">
+      <div className="mx-auto w-full max-w-[1600px] px-4 md:flex md:gap-6 md:px-6">
         {/* Wide enough to hold the wordmark and the footnote with air around
           them rather than to their exact width. It's held back at md, where
           every pixel it takes comes off a card. */}


### PR DESCRIPTION
Follow-up to #30, which merged the rail and header-search work but not this
last commit.

## The problem

The shell used Tailwind's `container`, which does not mean "fluid up to a
maximum" — it snaps `max-width` to a fixed value per breakpoint: 640, 768,
1024, 1280, 1536. Every width in between was left on the floor. At a 1000px
window the page was locked to 768 and a quarter of the screen sat empty; at
1200 it was locked to 1024.

The left rail from #30 made it worse, taking its ~200px out of an already
capped width rather than out of the window.

## The change

One line in `src/app/page.tsx`: `container` → `mx-auto w-full max-w-[1600px]`.

The whole shell — rail and content column together — now grows with the
window, so cards resize as it is dragged. It settles at 1600 including its
24px gutters, and centres beyond that rather than growing without end on a
very wide screen.

Column counts are deliberately left alone: they still switch at the same
viewport widths, and the cards now grow smoothly between those switches
instead of being pinned to one size across a whole band.

## Measured

Across 700/768/900/1000/1200/1280/1400/1600/1920 against a local database
with seeded rows:

| viewport | shell | cols | card before → after |
| --- | --- | --- | --- |
| 900 | 900 | 2 | 248 → 314 |
| 1000 | 1000 | 2 | 248 → 364 |
| 1200 | 1200 | 3 | 232 → 291 |
| 1400 | 1400 | 4 | 232 → 262 |
| 1600 | 1600 | 4 | 296 → 312 |
| 1920 | 1600, centred | 4 | 296 → 312 |

Also asserted at every width: shell is exactly `min(window, 1600)`, no
horizontal scrollbar, the rail holds 176 at md and 208 at lg, the header
control row never overflows, and search mode still fits at 900.

`tsc --noEmit`, `next lint` and `next build` all pass. No schema changes, so
there is no SQL to run with this one.

## Known limitation

The low end of each band is unchanged — at exactly 1280 the fourth column
still lands at 232px cards, as it does today. Shifting the column thresholds
up by roughly the rail's width would fix that, and is left for a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiD5VZB2LktAE2MehxrTU6)_